### PR TITLE
Implement ARO Classic cluster creation/deletion against a deployed full-service RP instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config_*.sh
 !config_example.sh
 secrets
 cluster-service-principal.json
+kubeconfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config_*.sh
 !config_example.sh
 secrets
+cluster-service-principal.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config_*.sh
+!config_example.sh
+secrets

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ installer-build-clean: ## Remove installer artifacts from the aro-e2e environmen
 ## Classic RP Targets
 ##
 
+classic-secrets:
+	./classic/config.sh secrets
+
 classic-bootstrap-azure: 
 	./classic/bootstrap.sh bootstrap-azure
 

--- a/Makefile
+++ b/Makefile
@@ -81,22 +81,9 @@ classic-create:
 classic-delete:
 	./classic/delete.sh delete-cluster
 
-classic-mock-bootstrap-azure: ## Bootstrap Azure resources for Classic ARO like cluster
-	./classic/bootstrap.sh mock-bootstrap-azure
-
-classic-mock-create: ## Create Classic ARO like cluster for testing
-	./classic/bootstrap.sh mock-create-cluster
-
-classic-mock-delete: ## Delete Classic ARO like cluster for testing
-	./classic/delete.sh mock-delete-cluster
-
 ################################################################################
 ## Workflow Targets
 ##
 
 wf-classic-cluster-conftest: ## Openshift conformance test workflow (Classic ARO using RP)
 	$(MAKE) classic-config-workflow classic-bootstrap-azure classic-create classic-conftest classic-delete classic-clean-bootstrap-azure
-
-wf-classic-mock-cluster-conftest: ## Openshift conformance test workflow (Classic ARO like)
-	$(MAKE) classic-config-workflow classic-mock-bootstrap-azure classic-mock-create classic-conftest classic-mock-delete
-

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,11 @@ installer-build-clean: ## Remove installer artifacts from the aro-e2e environmen
 classic-secrets:
 	./classic/config.sh secrets
 
-classic-bootstrap-azure: 
+classic-bootstrap-azure:
 	./classic/bootstrap.sh bootstrap-azure
+
+classic-clean-bootstrap-azure:
+	./classic/bootstrap.sh clean-bootstrap-azure
 
 classic-conftest: ## Run Openshift conformance tests
 	./classic/conftest.sh cluster-conftest
@@ -92,7 +95,7 @@ classic-mock-delete: ## Delete Classic ARO like cluster for testing
 ##
 
 wf-classic-cluster-conftest: ## Openshift conformance test workflow (Classic ARO using RP)
-	$(MAKE) classic-config-workflow classic-bootstrap-azure classic-create classic-conftest classic-delete
+	$(MAKE) classic-config-workflow classic-bootstrap-azure classic-create classic-conftest classic-delete classic-clean-bootstrap-azure
 
 wf-classic-mock-cluster-conftest: ## Openshift conformance test workflow (Classic ARO like)
 	$(MAKE) classic-config-workflow classic-mock-bootstrap-azure classic-mock-create classic-conftest classic-mock-delete

--- a/classic/bootstrap.bicep
+++ b/classic/bootstrap.bicep
@@ -1,0 +1,21 @@
+targetScope = 'resourceGroup'
+
+param location string = resourceGroup().location
+
+resource clusterVnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
+  name: 'cluster-vnet'
+  location: location
+  properties: { addressSpace: { addressPrefixes: ['10.0.0.0/22'] } }
+}
+
+resource masterSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  name: 'master'
+  parent: clusterVnet
+  properties: { addressPrefixes: ['10.0.0.0/23'] }
+}
+
+resource workerSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
+  name: 'worker'
+  parent: clusterVnet
+  properties: { addressPrefixes: ['10.0.2.0/23'] }
+}

--- a/classic/bootstrap.sh
+++ b/classic/bootstrap.sh
@@ -48,10 +48,6 @@ function clean-bootstrap-azure {
         --resource-group ${AZURE_CLUSTER_RESOURCE_GROUP}
 }
 
-function mock-bootstrap-azure {
-    echo "Bootstrap Azure resources for ARO like cluster"
-}
-
 ## Run function called from command line. ie: `boostrap.sh mock-bootstrap-azure`
 case $1 in
     bootstrap-azure)
@@ -59,9 +55,6 @@ case $1 in
     ;;
     clean-bootstrap-azure)
         clean-bootstrap-azure
-    ;;
-    mock-bootstrap-azure)
-        mock-bootstrap-azure
     ;;
     *)
         echo "No function named $1"

--- a/classic/bootstrap.sh
+++ b/classic/bootstrap.sh
@@ -2,6 +2,50 @@
 
 function bootstrap-azure {
     echo "Bootstrap Azure resources for ARO install with RP"
+    set -e
+
+    if [[ -z "${AZURE_SUBSCRIPTION_ID}" ]]; then
+        echo ">> AZURE_SUBSCRIPTION_ID is not set"
+        exit 1
+    fi
+
+    if [[ -z "${AZURE_CLUSTER_RESOURCE_GROUP}" ]]; then
+        echo ">> AZURE_CLUSTER_RESOURCE_GROUP is not set"
+        exit 1
+    fi
+
+    echo "Creating resource group ${AZURE_CLUSTER_RESOURCE_GROUP}"
+    az group create \
+        --subscription ${AZURE_SUBSCRIPTION_ID} \
+        --resource-group ${AZURE_CLUSTER_RESOURCE_GROUP} \
+        --location eastus
+
+    echo "Creating cluster resources"
+    az deployment group create \
+        --subscription ${AZURE_SUBSCRIPTION_ID} \
+        --resource-group ${AZURE_CLUSTER_RESOURCE_GROUP} \
+        --name cluster-resources \
+        --template-file ./classic/bootstrap.bicep
+}
+
+function clean-bootstrap-azure {
+    echo "Cleaning bootstrap Azure resources for ARO install with RP"
+    set -e
+
+    if [[ -z "${AZURE_SUBSCRIPTION_ID}" ]]; then
+        echo ">> AZURE_SUBSCRIPTION_ID is not set"
+        exit 1
+    fi
+
+    if [[ -z "${AZURE_CLUSTER_RESOURCE_GROUP}" ]]; then
+        echo ">> AZURE_CLUSTER_RESOURCE_GROUP is not set"
+        exit 1
+    fi
+
+    echo "Deleting cluster resource group"
+    az group delete --yes \
+        --subscription ${AZURE_SUBSCRIPTION_ID} \
+        --resource-group ${AZURE_CLUSTER_RESOURCE_GROUP}
 }
 
 function mock-bootstrap-azure {
@@ -12,6 +56,9 @@ function mock-bootstrap-azure {
 case $1 in
     bootstrap-azure)
         bootstrap-azure
+    ;;
+    clean-bootstrap-azure)
+        clean-bootstrap-azure
     ;;
     mock-bootstrap-azure)
         mock-bootstrap-azure

--- a/classic/config.sh
+++ b/classic/config.sh
@@ -4,10 +4,24 @@ function config-workflow {
     echo "Workflow config for Classic ARO cluster installs"
 }
 
+function secrets {
+    if [[ ! -v SECRET_SA_ACCOUNT_NAME ]]; then
+        echo ">> SECRET_SA_ACCOUNT_NAME is not set"
+        exit 1
+    fi
+    rm -rf secrets
+    az storage blob download -n secrets.tar.gz -c secrets -f secrets.tar.gz --account-name ${SECRET_SA_ACCOUNT_NAME} >/dev/null
+    tar -xzf secrets.tar.gz
+    rm secrets.tar.gz
+}
+
 ## Run function called from command line. ie: `config.sh config-workflow`
 case $1 in
     config-workflow)
         config-workflow
+    ;;
+    secrets)
+        secrets
     ;;
     *)
         echo "No function named $1"

--- a/classic/config.sh
+++ b/classic/config.sh
@@ -5,7 +5,7 @@ function config-workflow {
 }
 
 function secrets {
-    if [[ ! -v SECRET_SA_ACCOUNT_NAME ]]; then
+    if [[ -z "${SECRET_SA_ACCOUNT_NAME}" ]]; then
         echo ">> SECRET_SA_ACCOUNT_NAME is not set"
         exit 1
     fi

--- a/classic/conftest.sh
+++ b/classic/conftest.sh
@@ -14,7 +14,7 @@ function cluster-conftest {
     echo "Run OCP conformance tests"
 
     get-kubeconfig
-
+    KUBECONFIG=./kubeconfig
     # TODO - replace the below with actual tests
     oc --insecure-skip-tls-verify get nodes
 }

--- a/classic/conftest.sh
+++ b/classic/conftest.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 
+function get-kubeconfig {
+    echo "Getting cluster kubeconfig"
+    RESOURCE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_CLUSTER_RESOURCE_GROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${ARO_CLUSTER_NAME}"
+    curl -X POST \
+        -k "${RP_ENDPOINT}${RESOURCE_ID}/listadmincredentials?api-version=2023-11-22" \
+        --cert ./secrets/dev-client.pem \
+        --header "Content-Type: application/json" \
+        --silent | jq -r .kubeconfig | base64 -d > kubeconfig
+}
+
 function cluster-conftest {
     echo "Run OCP conformance tests"
+
+    get-kubeconfig
+
+    # TODO - replace the below with actual tests
+    oc --insecure-skip-tls-verify get nodes
 }
 
 ## Run function called from command line. ie: `conftest.sh cluster-conftest

--- a/classic/create.sh
+++ b/classic/create.sh
@@ -100,17 +100,10 @@ EOF
     done
 }
 
-function mock-create-cluster {
-    echo "Create ARO like cluster"
-}
-
 ## Run function called from command line. ie: `create.sh mock-create-cluster`
 case $1 in
     create-cluster)
         create-cluster
-    ;;
-    mock-create-cluster)
-        mock-create-cluster
     ;;
     *)
         echo "No function named $1"

--- a/classic/create.sh
+++ b/classic/create.sh
@@ -92,6 +92,19 @@ EOF
                 echo "Cluster creation completed successfully"
                 break
             ;;
+            "Failed")
+                echo "Cluster creation failed"
+                echo "Getting install logs"
+
+                curl -X GET \
+                    -k "${RP_ENDPOINT}/admin${RESOURCE_ID}/clusterdeployment?api-version=2023-11-22" \
+                    --cert ./secrets/dev-client.pem \
+                    --silent \
+                | jq -r '.status.conditions | map(select(.type == "ProvisionFailed")) | .[0].message' \
+                | sed -e 's/\\n/\n/g'
+
+                exit 1
+            ;;
             *)
                 echo "Cluster creation in unexpected state: ${STATE}"
                 exit 1

--- a/classic/create.sh
+++ b/classic/create.sh
@@ -2,6 +2,102 @@
 
 function create-cluster {
     echo "Create ARO cluster with RP"
+    set -eu
+
+    echo "Creating cluster service principal with name ${ARO_CLUSTER_SERVICE_PRINCIPAL_NAME}"
+    az ad sp create-for-rbac --name "${ARO_CLUSTER_SERVICE_PRINCIPAL_NAME}" > cluster-service-principal.json
+    CSP_CLIENTID=$(jq -r '.appId' cluster-service-principal.json)
+    CSP_CLIENTSECRET=$(jq -r '.password' cluster-service-principal.json)
+    CSP_OBJECTID=$(az ad sp show --id ${CSP_CLIENTID} -o json | jq -r '.id')
+    rm cluster-service-principal.json
+
+    echo "Creating role assignments for cluster service principal"
+    SCOPE="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_CLUSTER_RESOURCE_GROUP}"
+    az role assignment create \
+        --role 'User Access Administrator' \
+        --assignee-object-id ${CSP_OBJECTID} \
+        --scope ${SCOPE} \
+        --assignee-principal-type 'ServicePrincipal'
+
+    az role assignment create \
+        --role 'Contributor' \
+        --assignee-object-id ${CSP_OBJECTID} \
+        --scope ${SCOPE} \
+        --assignee-principal-type 'ServicePrincipal'
+
+    echo "Registering cluster version ${ARO_VERSION} to the RP"
+    curl -X PUT \
+        -k "${RP_ENDPOINT}/admin/versions" \
+        --cert ./secrets/dev-client.pem \
+        --header "Content-Type: application/json" \
+        --data-binary @- <<EOF
+{
+    "properties": { 
+        "version": "${ARO_VERSION}", 
+        "enabled": true, 
+        "openShiftPullspec": "${ARO_VERSION_OPENSHIFT_PULLSPEC}", 
+        "installerPullspec": "${ARO_VERSION_INSTALLER_PULLSPEC}" 
+    }
+}
+EOF
+
+    echo "Creating cluster"
+    RESOURCE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_CLUSTER_RESOURCE_GROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${ARO_CLUSTER_NAME}"
+    RANDOM_ID=$(tr -dc a-z </dev/urandom | head -c 1; tr -dc a-z0-9 </dev/urandom | head -c 7)
+    MANAGED_RESOURCE_GROUP_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/aro-${RANDOM_ID}"
+    VNET_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_CLUSTER_RESOURCE_GROUP}/providers/Microsoft.Network/virtualNetworks/cluster-vnet"
+    MASTER_SUBNET_ID="${VNET_ID}/subnets/master"
+    WORKER_SUBNET_ID="${VNET_ID}/subnets/worker"
+
+    curl -X PUT \
+        -k "${RP_ENDPOINT}${RESOURCE_ID}?api-version=2023-11-22" \
+        --cert ./secrets/dev-client.pem \
+        --header "Content-Type: application/json" \
+        --data-binary @- <<EOF
+{
+    "location": "eastus",
+    "properties": {
+        "clusterProfile": {
+            "domain": "${RANDOM_ID}", "resourceGroupId": "${MANAGED_RESOURCE_GROUP_ID}",
+            "version": "${ARO_VERSION}", "fipsValidatedModules": "Disabled"
+        },
+        "servicePrincipalProfile": {"clientId": "${CSP_CLIENTID}", "clientSecret": "${CSP_CLIENTSECRET}"},
+        "networkProfile": {"podCidr": "10.128.0.0/14", "serviceCidr": "172.30.0.0/16"},
+        "masterProfile": {
+            "vmSize": "Standard_D8s_v3", "subnetId": "${MASTER_SUBNET_ID}", "encryptionAtHost": "Disabled"
+        },
+        "workerProfiles": [{
+            "name": "worker", "count": 3, "diskSizeGb": 128,
+            "vmSize": "Standard_D2s_v3", "subnetId": "${WORKER_SUBNET_ID}", "encryptionAtHost": "Disabled"
+        }],
+        "apiserverProfile": {"visibility": "Public"},
+        "ingressProfiles": [{"name": "default", "visibility": "Public"}]
+    }
+}
+EOF
+
+    echo "Waiting for cluster creation to complete..."
+    while true
+    do
+        STATE=$(curl -X GET \
+            -k "${RP_ENDPOINT}${RESOURCE_ID}?api-version=2023-11-22" \
+            --cert ./secrets/dev-client.pem \
+            --silent | jq -r '.properties.provisioningState')
+
+        case $STATE in
+            "Creating")
+                sleep 30
+            ;;
+            "Succeeded")
+                echo "Cluster creation completed successfully"
+                break
+            ;;
+            *)
+                echo "Cluster creation in unexpected state: ${STATE}"
+                exit 1
+            ;;
+        esac
+    done
 }
 
 function mock-create-cluster {

--- a/classic/delete.sh
+++ b/classic/delete.sh
@@ -2,6 +2,50 @@
 
 function delete-cluster {
     echo "Delete ARO cluster with RP"
+    set -eu
+
+    RESOURCE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_CLUSTER_RESOURCE_GROUP}/providers/Microsoft.RedHatOpenShift/openShiftClusters/${ARO_CLUSTER_NAME}"
+
+    CSP_CLIENTID=$(curl -X GET \
+            -k "${RP_ENDPOINT}${RESOURCE_ID}?api-version=2023-11-22" \
+            --cert ./secrets/dev-client.pem \
+            --silent | jq -r '.properties.servicePrincipalProfile.clientId')
+    CSP_OBJECTID=$(az ad sp show --id ${CSP_CLIENTID} -o json | jq -r '.id')
+
+    echo "Deleting cluster"
+    curl -X DELETE \
+        -k "${RP_ENDPOINT}${RESOURCE_ID}?api-version=2023-11-22" \
+        --cert ./secrets/dev-client.pem
+
+    echo "Waiting for cluster deletion to complete..."
+    while true
+    do
+        STATE=$(curl -X GET \
+            -k "${RP_ENDPOINT}${RESOURCE_ID}?api-version=2023-11-22" \
+            --cert ./secrets/dev-client.pem \
+            --silent | jq -r '.properties.provisioningState')
+
+        case $STATE in
+            "Deleting")
+                sleep 30
+            ;;
+            "null")
+                echo "Cluster deletion completed successfully"
+                break
+            ;;
+            *)
+                echo "Cluster deletion in unexpected state: ${STATE}"
+                exit 1
+            ;;
+        esac
+    done
+
+    echo "Deleting CSP role assignments"
+    SCOPE="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_CLUSTER_RESOURCE_GROUP}"
+    az role assignment delete --assignee ${CSP_OBJECTID} --scope ${SCOPE}
+
+    echo "Deleting CSP"
+    az ad app delete --id ${CSP_CLIENTID}
 }
 
 function mock-delete-cluster {

--- a/classic/delete.sh
+++ b/classic/delete.sh
@@ -48,17 +48,10 @@ function delete-cluster {
     az ad app delete --id ${CSP_CLIENTID}
 }
 
-function mock-delete-cluster {
-    echo "Delete ARO like cluster"
-}
-
 ## Run function called from command line. ie: `delete.sh mock-delete-cluster`
 case $1 in
     delete-cluster)
         delete-cluster
-    ;;
-    mock-delete-cluster)
-        mock-delete-cluster
     ;;
     *)
         echo "No function named $1"

--- a/config_example.sh
+++ b/config_example.sh
@@ -33,5 +33,46 @@ export OPENSHIFT_CI_TOKEN=''
 
 # SECRET_SA_ACCOUNT_NAME - **REQUIRED**
 # The name of the storage account in Azure containing secrets necessary
-# to access the classic RP instance used to provision clusters
+# to access the classic RP instance used to provision clusters.
 export SECRET_SA_ACCOUNT_NAME=''
+
+# AZURE_SUBSCRIPTION_ID - **REQUIRED**
+# The UUID of the subscription in Azure to create the cluster+backing resources
+# within. Generally this will be the same subscription as the RP instance used
+# to provision clusters is in.
+export AZURE_SUBSCRIPTION_ID=''
+
+# AZURE_CLUSTER_RESOURCE_GROUP
+# Default: aro-${USER}
+# The name of the resource group to install the cluster resources (vnet) within.
+# It will be created and deleted as a part of the workflow.
+export AZURE_CLUSTER_RESOURCE_GROUP="aro-${USER}"
+
+# ARO_CLUSTER_SERVICE_PRINCIPAL_NAME
+# Default: aro-${USER}-csp
+# The name of the EntraID application to use as the cluster service principal.
+# It will be created and deleted as a part of the workflow.
+export ARO_CLUSTER_SERVICE_PRINCIPAL_NAME="aro-${USER}"
+
+# ARO_CLUSTER_NAME
+# Default: aro-${USER}
+# The name of the EntraID application to use as the cluster service principal.
+# It will be created and deleted as a part of the workflow.
+export ARO_CLUSTER_NAME="aro-${USER}"
+
+# ARO_VERSION - **REQUIRED**
+# The name of the ARO version to install, generally in the format:
+# `${OCP_VERSION}-${HASH}`. where $OCP_VERSION corresponds to an OCP X.Y.Z
+# release, and $HASH corresponds to the specific Git commit ref for an
+# installer-aro-wrapper image.
+export ARO_VERSION=''
+
+# ARO_VERSION_OPENSHIFT_PULLSPEC - **REQUIRED**
+# A reference to an ocp-release image, corresponding to the OCP version defined
+# in ARO_VERSION.
+export ARO_VERSION_OPENSHIFT_PULLSPEC=''
+
+# ARO_VERSION_INSTALLER_PULLSPEC - **REQUIRED**
+# A reference to an aro-installer image (built from openshift/installer-aro-wrapper),
+# corresponding to the OCP y-stream for the OCP version defined in ARO_VERSION.
+export ARO_VERSION_INSTALLER_PULLSPEC=''

--- a/config_example.sh
+++ b/config_example.sh
@@ -27,3 +27,11 @@ export CONTAINER_ENGINE_OPTS='--platform linux/amd64'
 # do expire after some time.
 export OPENSHIFT_CI_TOKEN=''
 
+################################################################################
+## ARO Classic Environment Settings
+##
+
+# SECRET_SA_ACCOUNT_NAME - **REQUIRED**
+# The name of the storage account in Azure containing secrets necessary
+# to access the classic RP instance used to provision clusters
+export SECRET_SA_ACCOUNT_NAME=''

--- a/config_example.sh
+++ b/config_example.sh
@@ -36,6 +36,11 @@ export OPENSHIFT_CI_TOKEN=''
 # to access the classic RP instance used to provision clusters.
 export SECRET_SA_ACCOUNT_NAME=''
 
+# RP_ENDPOINT - **REQUIRED**
+# The endpoint of the RP instance to provision clusters to provision clusters
+# with.
+export RP_ENDPOINT=
+
 # AZURE_SUBSCRIPTION_ID - **REQUIRED**
 # The UUID of the subscription in Azure to create the cluster+backing resources
 # within. Generally this will be the same subscription as the RP instance used
@@ -52,7 +57,7 @@ export AZURE_CLUSTER_RESOURCE_GROUP="aro-${USER}"
 # Default: aro-${USER}-csp
 # The name of the EntraID application to use as the cluster service principal.
 # It will be created and deleted as a part of the workflow.
-export ARO_CLUSTER_SERVICE_PRINCIPAL_NAME="aro-${USER}"
+export ARO_CLUSTER_SERVICE_PRINCIPAL_NAME="aro-${USER}-csp"
 
 # ARO_CLUSTER_NAME
 # Default: aro-${USER}


### PR DESCRIPTION
### Which issue this PR addresses:

Part of [ARO-5121](https://issues.redhat.com/browse/ARO-5121) and [ARO-5122](https://issues.redhat.com/browse/ARO-5122)

### What this PR does / why we need it:

- Implements a `classic-secrets` target to pull credentials for a full-service RP instance from an Azure storage account. 
- Implements the `bootstrap-azure` target and creates a parallel `clean-bootstrap-azure` target to create the backing resources for an ARO cluster (Azure resource group and virtual network w/ master/worker subnets)
- Implements the `classic-create` and `classic-delete` targets to provision ARO clusters using the deployed full-service RP instance. Invoking users are expected to populate the corresponding coordinates and credentials via environment variables. 

### Test plan for issue:

- [X] Manually invoke the targets (on my machine) and confirm they produce the desired results
- [x] Manually invoked the targets from a clean environment and confirm they produce the desired results

### Is there any documentation that needs to be updated for this PR?

Not yet

