### PR TITLE
Enable ansible cluster creation on arm64 container engines, plus minor fixes to ansible upgrade task and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config_*.sh
 secrets
 cluster-service-principal.json
 kubeconfig
+*.kubeconfig

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -23,10 +23,10 @@ To personalize the resulting resource groups, set the `CLUSTERPREFIX` as desired
 $ make cluster CLUSTERPREFIX=ocpbugs35300
 ```
 
-The default region used is `eastus`. Set the `REGION` parameter to choose a different region:
+The default region used is `eastus`. Set the `LOCATION` parameter to choose a different region:
 
 ```shell
-$ make cluster REGION=centraluseuap
+$ make cluster LOCATION=centraluseuap
 ```
 
 To choose one or more cluster configurations, set the `CLUSTERPATTERN` parameter to a wildcard string that matches the cluster scenarios you wish to test:

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -14,6 +14,7 @@
 - name: create_aro_cluster | Debug localhost facts
   ansible.builtin.debug:
     var: localhost_facts
+    verbosity: 3
 
 - name: create_aro_cluster | Enable preview az aro extension (by version number)
   when: AZAROEXT_VERSION is defined and "://" not in AZAROEXT_VERSION

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -4,6 +4,17 @@
   ansible.builtin.include_tasks:
     file: ../../tasks/create_jumphost.yaml
 
+- name: create_aro_cluster | Gather localhost facts
+  # Registering localhost_facts as a workaround for delegation/hostname resolution issues
+  # in `Gathering Facts` task when setting `gather_facts: true` in deployment playbook.
+  ansible.builtin.setup:
+  delegate_to: localhost
+  register: localhost_facts
+
+- name: create_aro_cluster | Debug localhost facts
+  ansible.builtin.debug:
+    var: localhost_facts
+
 - name: create_aro_cluster | Enable preview az aro extension (by version number)
   when: AZAROEXT_VERSION is defined and "://" not in AZAROEXT_VERSION
   block:
@@ -730,13 +741,21 @@
   ansible.builtin.fail:
     msg: "Cluster operator {{ item.name }} {{ item.condition.type }} is {{ item.condition.status }}."
 
+- name: create_aro_cluster | Register oc_arch
+  ansible.builtin.set_fact:
+    oc_arch: "{{ oc_arch_map[localhost_facts.ansible_facts['ansible_architecture']] }}"
+  vars:
+    oc_arch_map:
+      aarch64: arm64
+      x86_64: amd64
+
 - name: create_aro_cluster | Install `oc` binary from cluster
   ansible.builtin.unarchive:
     creates: /usr/local/bin/oc
     src: >
       {{ aro_cluster_state.clusters.properties.consoleProfile.url
          | replace('console-openshift-console', 'downloads-openshift-console')
-      }}amd64/linux/oc.tar
+      }}{{ oc_arch }}/linux/oc.tar
     remote_src: true
     dest: /usr/local/bin/
     include: ["oc"]

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
@@ -90,8 +90,8 @@
       delegate_to: localhost
       register: jumphost_cat_hostkeys_result
       changed_when: jumphost_cat_hostkeys_result.rc == 0
-      retries: 10 # Wait for jumphost VM to boot
-      delay: 10
+      retries: 40 # Wait for jumphost VM to boot
+      delay: 20
     - name: create_jumphost | Set fact jumphost_cat_hostkeys
       ansible.builtin.set_fact:
         jumphost_cat_hostkeys: "{{ jumphost_cat_hostkeys_result.stdout | from_yaml }}"

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
@@ -219,7 +219,7 @@
         resource_definition:
           spec:
             desiredUpdate:
-              force: '{{ upgrade_item.force | default("")'
+              force: '{{ upgrade_item.force | default("") | bool }}'
               image: '{{ upgrade_item.image | default("") }}'
               version: '{{ upgrade_item.version | default("") }}'
       delegate_to: "{{ delegation }}"


### PR DESCRIPTION
### What this PR does / why we need it:
- Enables ansible `create_aro_cluster` task to obtain `oc` binary correctly on both arm64 and amd64-based container engines.
- Makes some minor improvements to ansible cluster creation and upgrades:
  - in `ansible/README.md` (correcting the use of env `LOCATION` instead of `REGION`)
  - in `.gitignore` (adding `*.kubeconfig` files)
  - avoid timeouts while waiting for jumphost VM to boot during creation of cluster with UserDefinedRouting
- Bug fixes: resolve fatal `Invalid value` error in `upgrade_cluster` task (cast `spec.desiredUpdate.force` as bool)