### PR TITLE
Normalize retry delays to 60 seconds

### DIFF
--- a/ansible_collections/azureredhatopenshift/cluster/roles/miwi_cluster/tasks/create_identities.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/roles/miwi_cluster/tasks/create_identities.yaml
@@ -29,7 +29,7 @@
     role_definition_id: "/subscriptions/{{ sub_info.subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/ef318e2a-8334-4a05-9e4a-295a196c6a6e" # RoleAzureRedHatOpenShiftFederatedCredentialRole
   delegate_to: localhost
   retries: 3 # Retry because it might need to propagate
-  delay: 10
+  delay: 60
 - name: create_identities | Mock MSI role assignment
   # when: mock_msi_object_id is defined
   azure.azcollection.azure_rm_roleassignment:

--- a/ansible_collections/azureredhatopenshift/cluster/roles/refresh_credentials/tasks/main.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/roles/refresh_credentials/tasks/main.yaml
@@ -29,8 +29,8 @@
   delegate_to: localhost
   register: cluster_status
   until: cluster_status.clusters.properties.provisioningState == 'Succeeded'
-  retries: 6
-  delay: 10
+  retries: 3
+  delay: 60
 - name: Get new secret/azure-credentials
   ansible.builtin.command:
     argv:

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -297,8 +297,8 @@
     host: localhost
     port: "8443"
     get_certificate_chain: true
-  retries: 6
-  delay: 10
+  retries: 3
+  delay: 60
   delegate_to: "{{ delegation }}"
   register: localrp_certificate
 - name: create_aro_cluster | Debug localrp_certificate
@@ -385,8 +385,8 @@
     host: "{{ aro_cluster_state.clusters.properties.apiserverProfile.url | urlsplit('hostname') }}"
     port: "{{ aro_cluster_state.clusters.properties.apiserverProfile.url | urlsplit('port') }}"
     get_certificate_chain: true
-  retries: 6
-  delay: 10
+  retries: 3
+  delay: 60
   delegate_to: "{{ delegation }}"
   register: apiserver_certificate
 - name: create_aro_cluster | Debug apiserver_certificate
@@ -401,8 +401,8 @@
     # port: "{{ aro_cluster_state.clusters.properties.consoleProfile.url | urlsplit('port') }} | default(443)"
     port: 443
     get_certificate_chain: true
-  retries: 6
-  delay: 10
+  retries: 3
+  delay: 60
   delegate_to: "{{ delegation }}"
   register: ingress_certificate
 - name: create_aro_cluster | Debug ingress_certificate
@@ -418,8 +418,8 @@
     validate_certs: false
     status_code:
       - 200
-  retries: 6
-  delay: 10
+  retries: 3
+  delay: 60
   register: api_healthz
   failed_when: api_healthz.status != 200 or api_healthz.content != "ok"
   delegate_to: "{{ delegation }}"
@@ -622,11 +622,6 @@
     clusterversion_conditions: |
       {{ oc_get_clusterversion.resources[0].status.conditions
          | items2dict(key_name="type", value_name="status") }}
-  # failed_when: |
-  #   clusterversion_conditions.get("Available", "False") != "True"
-  #   or clusterversion_conditions.get("Progressing", "False") == "True"
-  # retries: 30
-  # delay: 60
 - name: create_aro_cluster | Debug oc_get_clusterversion spec
   ansible.builtin.debug:
     var: oc_get_clusterversion.resources[0].spec

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
@@ -90,8 +90,8 @@
       delegate_to: localhost
       register: jumphost_cat_hostkeys_result
       changed_when: jumphost_cat_hostkeys_result.rc == 0
-      retries: 40 # Wait for jumphost VM to boot
-      delay: 20
+      retries: 12 # Wait for jumphost VM to boot
+      delay: 60
     - name: create_jumphost | Set fact jumphost_cat_hostkeys
       ansible.builtin.set_fact:
         jumphost_cat_hostkeys: "{{ jumphost_cat_hostkeys_result.stdout | from_yaml }}"


### PR DESCRIPTION
Normalize retry delays to 60 seconds to make it easier to tell at a glance how long a task will retry for