### PR TITLE
chore: bump ansible container versions

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -4,18 +4,22 @@ ARG VERSION
 ###############################################################################
 # ansible is the base Python image with ansible and azure-cli
 ###############################################################################
-FROM ${REGISTRY}/ubi9/python-311:1-66 AS ansible
+FROM ${REGISTRY}/ubi9/python-312:1-25 AS ansible
 # Versions
+# python-311 container:
+#   $ skopeo list-tags docker://registry.access.redhat.com/ubi9/python-312 | jq '.Tags[] | select(test("^[0-9]-[0-9]+$"))' | tail -n 1
+# Check azure-cli release notes to see if it supports a newer Python:
+#   https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli
 # pipx https://pypi.org/project/pipx/#history
 # azure-cli https://pypi.org/project/azure-cli/#history
 # ansible https://pypi.org/project/ansible/#history
 # ansible.azcollection https://galaxy.ansible.com/ui/repo/published/azure/azcollection/
 # https://pypi.org/project/ansible-lint/#history
 ARG PIPX_VERSION=1.7.1 \
-    ANSIBLE_VERSION=10.6.0 \
-    AZURE_CLI_VERSION=2.66.0 \
-    ANSIBLE_AZCOLLECTION_VERSION=3.0.0 \
-    ANSIBLE_LINT_VERSION=24.10.0
+    ANSIBLE_VERSION=11.3.0 \
+    AZURE_CLI_VERSION=2.70.0 \
+    ANSIBLE_AZCOLLECTION_VERSION=3.3.1 \
+    ANSIBLE_LINT_VERSION=25.1.3
 
 # Have Ansible to print task timing information
 ENV ANSIBLE_CALLBACKS_ENABLED=profile_tasks
@@ -31,13 +35,13 @@ RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
     ${APP_ROOT}/bin/pipx install "ansible==${ANSIBLE_VERSION}" --include-deps && \
     ${APP_ROOT}/bin/pipx inject --include-apps ansible "ansible-lint==${ANSIBLE_LINT_VERSION}" && \
     ansible-galaxy collection install --force azure.azcollection==$ANSIBLE_AZCOLLECTION_VERSION && \
-    ${APP_ROOT}/bin/pipx runpip ansible install -r "${HOME}/.local/share/pipx/venvs/ansible/lib/python3.11/site-packages/ansible_collections/azure/azcollection/requirements.txt"
+    ${APP_ROOT}/bin/pipx runpip ansible install -r "${HOME}/.local/share/pipx/venvs/ansible/lib/python${PYTHON_VERSION}/site-packages/ansible_collections/azure/azcollection/requirements.txt"
 RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
     ${APP_ROOT}/bin/pipx list && \
     rm -rf ${HOME}/.ansible ${HOME}/.azure
 
 COPY ansible /ansible
-COPY ansible_collections/azureredhatopenshift /opt/app-root/src/.local/share/pipx/venvs/ansible/lib/python3.11/site-packages/ansible_collections/azureredhatopenshift/
+COPY ansible_collections/azureredhatopenshift /opt/app-root/src/.local/share/pipx/venvs/ansible/lib/python${PYTHON_VERSION}/site-packages/ansible_collections/azureredhatopenshift/
 WORKDIR /ansible
 RUN --mount=type=cache,target=/root/.cache/pip/,sharing=locked \
     ${APP_ROOT}/bin/pipx runpip ansible install --upgrade -r "/ansible/ansible-requirements.txt" && \

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -292,6 +292,7 @@
     host: localhost
     port: "8443"
     get_certificate_chain: true
+    asn1_base64: true
   retries: 3
   delay: 60
   delegate_to: "{{ delegation }}"
@@ -381,6 +382,7 @@
     host: "{{ aro_cluster_state.clusters.properties.apiserverProfile.url | urlsplit('hostname') }}"
     port: "{{ aro_cluster_state.clusters.properties.apiserverProfile.url | urlsplit('port') }}"
     get_certificate_chain: true
+    asn1_base64: true
   retries: 3
   delay: 60
   delegate_to: "{{ delegation }}"
@@ -396,6 +398,7 @@
     # port: "{{ aro_cluster_state.clusters.properties.consoleProfile.url | urlsplit('port') }} | default(443)"
     port: 443
     get_certificate_chain: true
+    asn1_base64: true
   retries: 3
   delay: 60
   delegate_to: "{{ delegation }}"


### PR DESCRIPTION
Bump versions
* ubi9/python base image to 3.12:1-25
* ansible to 11.3.0
* azure-cli to 2.70.0
* ansible azcollection to 3.3.1
* ansible-lint to 25.1.3