### PR TITLE
Fix ansible task for private and UDR cluster creation from arm64 ansible host, and extend inventory for upgrades to 4.17 and 4.18

### DIFF
--- a/ansible/inventory/upgrades.yaml
+++ b/ansible/inventory/upgrades.yaml
@@ -43,6 +43,27 @@ all:
           version: 4.16.4
           admin_acks:
             - { "data": { "ack-4.15-kube-1.29-api-removals-in-4.16": "true" } }
+      to_417: &upgrade_to_417
+        #
+        # https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.16&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.16.0&target_ocp_version=4.17.15
+        - from: "4.16"
+          channel: stable-4.17
+          version: 4.17.15
+          #admin_acks:
+          # No admin-acks identified at https://docs.openshift.com/container-platform/4.17/updating/preparing_for_updates/updating-cluster-prepare.html
+      to_418: &upgrade_to_418
+        #
+        # https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.16&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.16.0&target_ocp_version=4.17.15
+        - from: "4.16"
+          channel: stable-4.17
+          version: 4.17.15
+          #admin_acks:
+          # No admin-acks identified at https://docs.openshift.com/container-platform/4.17/updating/preparing_for_updates/updating-cluster-prepare.html
+        - from: "4.17"
+          channel: fast-4.18   # https://access.redhat.com/support/policy/updates/openshift#dates  4.18 GA on 2025-02-25.  Use fast-4.18 until update available in stable-4.18 (estimated GA + 45-90d per https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/understanding-openshift-updates-1#update-availability_understanding-openshift-updates)
+          version: 4.18.4
+          #admin_acks:
+          # No admin-acks identified at https://docs.openshift.com/container-platform/4.18/updating/preparing_for_updates/updating-cluster-prepare.html
       fast_413: &upgrade_fast_413
         - from: "4.12"
           channel: fast-4.13
@@ -177,6 +198,14 @@ standard_clusters:
       name: aro
       version: 4.13.40
       upgrade: *upgrade_41346
+    416to417:
+      name: aro
+      version: 4.16.30
+      upgrade: *upgrade_to_417
+    416to418:
+      name: aro
+      version: 4.16.30
+      upgrade: *upgrade_to_418
     fast-413:
       name: aro
       version: 4.12.25
@@ -332,6 +361,14 @@ private_clusters:
       name: aro
       version: 4.12.25
       upgrade: *upgrade_to_415
+    private-416to417:
+      name: aro
+      version: 4.16.30
+      upgrade: *upgrade_to_417
+    private-416to418:
+      name: aro
+      version: 4.16.30
+      upgrade: *upgrade_to_418
   vars:
     apiserver_visibility: Private
     ingress_visibility: Private
@@ -344,6 +381,14 @@ private_clusters:
 udr_clusters:
   # https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x
   hosts:
+    udr416:
+      name: aro
+      version: 4.16.30
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
     udr414:
       name: aro-414
       version: 4.14.16
@@ -394,6 +439,24 @@ udr_clusters:
           address_prefix: 0.0.0.0/0
           next_hop_type: none
       upgrade: *upgrade_to_416
+    udr-416to417:
+      name: aro
+      version: 4.16.30
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+      upgrade: *upgrade_to_417
+    udr-416to418:
+      name: aro
+      version: 4.16.30
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+      upgrade: *upgrade_to_418
   vars:
     resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
     network_prefix_cidr: 10.0.0.0/22

--- a/ansible/inventory/upgrades.yaml
+++ b/ansible/inventory/upgrades.yaml
@@ -50,7 +50,7 @@ all:
           channel: stable-4.17
           version: 4.17.15
           #admin_acks:
-          # No admin-acks identified at https://docs.openshift.com/container-platform/4.17/updating/preparing_for_updates/updating-cluster-prepare.html
+          # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
       to_418: &upgrade_to_418
         #
         # https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.16&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.16.0&target_ocp_version=4.17.15
@@ -58,12 +58,12 @@ all:
           channel: stable-4.17
           version: 4.17.15
           #admin_acks:
-          # No admin-acks identified at https://docs.openshift.com/container-platform/4.17/updating/preparing_for_updates/updating-cluster-prepare.html
+          # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
         - from: "4.17"
           channel: fast-4.18   # https://access.redhat.com/support/policy/updates/openshift#dates  4.18 GA on 2025-02-25.  Use fast-4.18 until update available in stable-4.18 (estimated GA + 45-90d per https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/understanding-openshift-updates-1#update-availability_understanding-openshift-updates)
           version: 4.18.4
           #admin_acks:
-          # No admin-acks identified at https://docs.openshift.com/container-platform/4.18/updating/preparing_for_updates/updating-cluster-prepare.html
+          # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
       fast_413: &upgrade_fast_413
         - from: "4.12"
           channel: fast-4.13

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -726,7 +726,9 @@
 
 - name: create_aro_cluster | Register oc_arch
   ansible.builtin.set_fact:
-    oc_arch: "{{ oc_arch_map[localhost_facts.ansible_facts['ansible_architecture']] }}"
+    oc_arch: >-
+      {{ oc_arch_map[localhost_facts.ansible_facts['ansible_architecture']] if delegation == "localhost"
+      else oc_arch_map[jumphost_facts.ansible_facts['ansible_architecture']] }}
   vars:
     oc_arch_map:
       aarch64: arm64


### PR DESCRIPTION
### What this PR does / why we need it:

- Update `create_aro_cluster` to fetch the `oc` binary matching the Ansible delegate's (jumphost's) CPU architecture, rather than the Ansible host's. This prevents failures when the Ansible host and jumphost have different architectures.
- Extend ansible inventory to include upgrade paths for OCP 4.17 and 4.18, and add associated host targets for standard, private, and UDR clusters.