### PR TITLE
Improve compatibility with local rp testing via ARO-RP compose

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -1,10 +1,7 @@
-ARG REGISTRY
-ARG VERSION
-
 ###############################################################################
 # ansible is the base Python image with ansible and azure-cli
 ###############################################################################
-FROM ${REGISTRY}/ubi9/python-312:1-25 AS ansible
+FROM registry.access.redhat.com/ubi9/python-312:1-25 AS ansible
 # Versions
 # python-311 container:
 #   $ skopeo list-tags docker://registry.access.redhat.com/ubi9/python-312 | jq '.Tags[] | select(test("^[0-9]-[0-9]+$"))' | tail -n 1

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ ansible-image:
 		--build-arg REGISTRY=$(REGISTRY) \
 		--build-arg VERSION=$(VERSION) \
 		--no-cache=$(NO_CACHE) \
-		--tag aro-ansible:$(VERSION)
+		--tag aro-ansible:$(VERSION) \
+		--tag aro-ansible:latest
 
 LOCATION ?= eastus
 CLUSTERPREFIX ?= $(USER)

--- a/ansible/ansible-requirements.txt
+++ b/ansible/ansible-requirements.txt
@@ -1,1 +1,1 @@
-kubernetes==31.0.0
+kubernetes==32.0.1

--- a/ansible/azcli-requirements.txt
+++ b/ansible/azcli-requirements.txt
@@ -1,1 +1,0 @@
-azure-mgmt-rdbms==10.2.0b17  # https://github.com/Azure/azure-cli/issues/30102

--- a/ansible_collections/azureredhatopenshift/cluster/roles/refresh_credentials/tasks/main.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/roles/refresh_credentials/tasks/main.yaml
@@ -23,7 +23,7 @@
 - name: Wait for provisioningState to become Succeeded
   azureredhatopenshift.cluster.azure_rm_openshiftmanagedcluster_info:
     api_version: "{{ aro_api_version | d(omit) }}"
-    rp_mode: "{% if platform_workload_identities is defined %}development{% else %}{{ omit }}{% endif %}"
+    rp_mode: "{{ rp_mode | default(omit) }}"
     name: "{{ name }}"
     resource_group: "{{ resource_group }}"
   delegate_to: localhost

--- a/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/refresh_credentials.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/refresh_credentials.yaml
@@ -28,7 +28,7 @@
 - name: refresh_credentials | Wait for provisioningState to become Succeeded
   azureredhatopenshift.cluster.azure_rm_openshiftmanagedcluster_info:
     api_version: "{{ aro_api_version | d(omit) }}"
-    rp_mode: "{% if platform_workload_identities is defined %}development{% else %}{{ omit }}{% endif %}"
+    rp_mode: "{{ rp_mode | default(omit) }}"
     name: "{{ name }}"
     resource_group: "{{ resource_group }}"
   delegate_to: localhost

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -40,6 +40,78 @@
       when: pull_secret_file_stat_exists | default(false)
       run_once: true
       delegate_to: localhost
+- name: create_aro_cluster | Local RP certificate
+  when: rp_mode|default("production") == "development"
+  community.crypto.get_certificate:
+    host: localhost
+    port: "8443"
+    get_certificate_chain: true
+    asn1_base64: true
+  retries: 3
+  delay: 60
+  delegate_to: "{{ delegation }}"
+  register: localrp_certificate
+- name: create_aro_cluster | Debug localrp_certificate
+  ansible.builtin.debug:
+    var: localrp_certificate
+    verbosity: 1
+- name: create_aro_cluster | Trust the local RP's' certificate on jumphost
+  # Note: is this needed? We should be doing all RP interactions from the local
+  # container, not from the jumphost.
+  when: rp_mode|default("production") == "development" and delegation != "localhost"
+  block:
+    - name: create_aro_cluster | Install local RP's certificate locally
+      ansible.builtin.copy:
+        dest: /usr/local/share/ca-certificates/aro-rp.crt
+        content: "{% for item in localrp_certificate.verified_chain %}{{ item }}{% endfor %}"
+        mode: "0644"
+        owner: root
+        group: root
+      become: true
+      delegate_to: "{{ delegation }}"
+      register: localrp_ca_certificate
+    - name: create_aro_cluster | Update CA Certificates
+      when: localrp_ca_certificate is changed # noqa no-handler
+      ansible.builtin.command:
+        argv: ["update-ca-certificates"]
+      become: true
+      delegate_to: "{{ delegation }}"
+      register: update_ca_certificates
+      changed_when: true
+    - name: create_aro_cluster | Debug update_ca_certificates
+      ansible.builtin.debug:
+        var: update_ca_certificates.stdout_lines
+        verbosity: 1
+- name: create_aro_cluster | Trust the local RP's certificate
+  when: rp_mode|default("production") == "development"
+  block:
+    - name: create_aro_cluster | Install local RP's certificate locally (RHEL version)
+      ansible.builtin.copy:
+        dest: /etc/pki/ca-trust/source/anchors/aro-rp.crt
+        content: "{% for item in localrp_certificate.verified_chain %}{{ item }}{% endfor %}"
+        mode: "0644"
+        owner: root
+        group: root
+      become: true
+      delegate_to: localhost
+      register: localrp_ca_certificate
+    - name: create_aro_cluster | Update CA Certificates
+      when: localrp_ca_certificate is changed # noqa no-handler
+      ansible.builtin.command:
+        argv: ["update-ca-trust"]
+      become: true
+      delegate_to: localhost
+      register: update_ca_certificates
+      changed_when: true
+    - name: create_aro_cluster | Debug update_ca_certificates
+      when: ansible_verbosity > 0
+      ansible.builtin.debug:
+        var: update_ca_certificates.stdout_lines
+- name: create_aro_cluster | Debug localrp_ca_certificate
+  when: localrp_ca_certificate is defined
+  ansible.builtin.debug:
+    var: localrp_ca_certificate
+    verbosity: 1
 
 - name: create_aro_cluster | Enable preview az aro extension (by version number)
   when: AZAROEXT_VERSION is defined and "://" not in AZAROEXT_VERSION
@@ -143,7 +215,7 @@
 - name: create_aro_cluster | Wait for existing cluster to finish
   azureredhatopenshift.cluster.azure_rm_openshiftmanagedcluster_info:
     api_version: "{{ aro_api_version | d(omit) }}"
-    rp_mode: "{% if platform_workload_identities is defined %}development{% else %}{{ omit }}{% endif %}"
+    rp_mode: "{{ rp_mode | default(omit) }}"
     name: "{{ name }}"
     resource_group: "{{ resource_group }}"
   delegate_to: localhost
@@ -155,19 +227,19 @@
   delay: 60
 
 - name: create_aro_cluster | Create cluster via module
-  when: aro_api_version is defined
+  when: aro_api_version is defined or rp_mode | default("production") == "development"
   ansible.builtin.include_tasks:
     file: ../../tasks/create_cluster_module.yaml
 
 - name: create_aro_cluster | Create cluster via cli
-  when: aro_api_version is not defined
+  when: aro_api_version is not defined or rp_mode | default("production") != "development"
   ansible.builtin.include_tasks:
     file: ../../tasks/create_cluster_azcli.yaml
 
 - name: create_aro_cluster | Wait for cluster to finish creating or deleting
   azureredhatopenshift.cluster.azure_rm_openshiftmanagedcluster_info:
     api_version: "{{ aro_api_version | d(omit) }}"
-    rp_mode: "{% if platform_workload_identities is defined %}development{% else %}{{ omit }}{% endif %}"
+    rp_mode: "{{ rp_mode | default(omit) }}"
     name: "{{ name }}"
     resource_group: "{{ resource_group }}"
   delegate_to: localhost
@@ -181,7 +253,7 @@
 - name: create_aro_cluster | Get cluster status
   azureredhatopenshift.cluster.azure_rm_openshiftmanagedcluster_info:
     api_version: "{{ aro_api_version | d(omit) }}"
-    rp_mode: "{% if platform_workload_identities is defined %}development{% else %}{{ omit }}{% endif %}"
+    rp_mode: "{{ rp_mode | default(omit) }}"
     name: "{{ name }}"
     resource_group: "{{ resource_group }}"
   delegate_to: localhost
@@ -316,76 +388,6 @@
   register: az_vm_runcommand_jumphost
   changed_when: az_vm_runcommand_jumphost.rc == 0
 
-- name: create_aro_cluster | Local RP certificate
-  when: rp_mode|default("production") == "development"
-  community.crypto.get_certificate:
-    host: localhost
-    port: "8443"
-    get_certificate_chain: true
-    asn1_base64: true
-  retries: 3
-  delay: 60
-  delegate_to: "{{ delegation }}"
-  register: localrp_certificate
-- name: create_aro_cluster | Debug localrp_certificate
-  ansible.builtin.debug:
-    var: localrp_certificate
-    verbosity: 1
-- name: create_aro_cluster | Trust the local RP's' certificate (Debian version)
-  when: rp_mode|default("production") == "development" and delegation != "localhost"
-  block:
-    - name: create_aro_cluster | Install local RP's certificate locally
-      ansible.builtin.copy:
-        dest: /usr/local/share/ca-certificates/aro-rp.crt
-        content: "{% for item in localrp_certificate.verified_chain %}{{ item }}{% endfor %}"
-        mode: "0644"
-        owner: root
-        group: root
-      become: true
-      delegate_to: "{{ delegation }}"
-      register: localrp_ca_certificate
-    - name: create_aro_cluster | Update CA Certificates
-      when: localrp_ca_certificate is changed # noqa no-handler
-      ansible.builtin.command:
-        argv: ["update-ca-certificates"]
-      become: true
-      delegate_to: "{{ delegation }}"
-      register: update_ca_certificates
-      changed_when: true
-    - name: create_aro_cluster | Debug update_ca_certificates
-      ansible.builtin.debug:
-        var: update_ca_certificates.stdout_lines
-        verbosity: 1
-- name: create_aro_cluster | Trust the local RP's certificate (RHEL version)
-  when: rp_mode|default("production") == "development" and delegation == "localhost"
-  block:
-    - name: create_aro_cluster | Install local RP's certificate locally (RHEL version)
-      ansible.builtin.copy:
-        dest: /etc/pki/ca-trust/source/anchors/aro-rp.crt
-        content: "{% for item in localrp_certificate.verified_chain %}{{ item }}{% endfor %}"
-        mode: "0644"
-        owner: root
-        group: root
-      become: true
-      delegate_to: "{{ delegation }}"
-      register: localrp_ca_certificate
-    - name: create_aro_cluster | Update CA Certificates
-      when: localrp_ca_certificate is changed # noqa no-handler
-      ansible.builtin.command:
-        argv: ["update-ca-trust"]
-      become: true
-      delegate_to: "{{ delegation }}"
-      register: update_ca_certificates
-      changed_when: true
-    - name: create_aro_cluster | Debug update_ca_certificates
-      when: ansible_verbosity > 0
-      ansible.builtin.debug:
-        var: update_ca_certificates.stdout_lines
-- name: create_aro_cluster | Debug localrp_ca_certificate
-  when: localrp_ca_certificate is defined
-  ansible.builtin.debug:
-    var: localrp_ca_certificate
-    verbosity: 1
 - name: create_aro_cluster | Get cluster kubeconfig
   ansible.builtin.command:
     argv:

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_cluster_azcli.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_cluster_azcli.yaml
@@ -1,7 +1,7 @@
 - name: cluster_create_azcli | Get cluster status
   azureredhatopenshift.cluster.azure_rm_openshiftmanagedcluster_info:
     api_version: "{{ aro_api_version | d(omit) }}"
-    rp_mode: "{% if platform_workload_identities is defined %}development{% else %}{{ omit }}{% endif %}"
+    rp_mode: "{{ rp_mode | default(omit) }}"
     name: "{{ name }}"
     resource_group: "{{ resource_group }}"
   delegate_to: localhost
@@ -49,7 +49,7 @@
       - "{% if worker_count is defined %}--worker-count={{ worker_count }}{% else %}{{ omit }}{% endif %}"
       - "{% if worker_vm_size is defined %}--worker-vm-size={{ worker_vm_size }}{% else %}{{ omit }}{% endif %}"
       - --tags
-      - createdby={{ currentuser_info.userPrincipalName }} createdwith=ansible purge=true
+      - createdby={{ currentuser_info.userPrincipalName | default(lookup("env", "AZURE_CLIENT_ID")) | default("unknown") }} createdwith=ansible purge=true
       - -o=yaml
   register: az_aro_create_output
   ignore_errors: true

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_cluster_module.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_cluster_module.yaml
@@ -1,7 +1,7 @@
 - name: cluster_create_module | Create aro cluster
   azureredhatopenshift.cluster.azure_rm_openshiftmanagedcluster:
     api_version: "{{ aro_api_version | d(omit) }}"
-    rp_mode: "{% if platform_workload_identities is defined %}development{% else %}{{ omit }}{% endif %}"
+    rp_mode: "{{ rp_mode | default(omit) }}"
     name: "{{ name }}"
     resource_group: "{{ resource_group }}"
     location: "{{ location }}"
@@ -13,17 +13,17 @@
       fips_validated_modules: "{{ fips_validated_modules | d(omit) }}"
       version: "{{ version | d(omit) }}"
     identity:
-      type: UserAssigned # Only UserAssigned is supported
-      user_assigned_identities: "{{ user_assigned_identities }}"
+      type: "{% if user_assigned_identities is defined %}UserAssigned{% else %}{{ omit }}{% endif %}" # Only UserAssigned is supported
+      user_assigned_identities: "{{ user_assigned_identities | d(omit) }}"
     platform_workload_identity_profile:
       upgradeable_to: "{{ omit }}"
-      platform_workload_identities: "{{ platform_workload_identities }}"
+      platform_workload_identities: "{{ platform_workload_identities | d(omit) }}"
     ingress_profiles:
       - visibility: "{{ ingress_visibility | d('Public') }}"
     master_profile:
       vm_size: "{{ master_vm_size | d(omit) }}"
       subnet_id: "{{ master_subnet_state.state.id }}"
-      encryption_at_host: "{{ master_encryption_at_host | d(omit) }}"
+      encryption_at_host: "{% if master_encryption_at_host | d(False) %}Enabled{% else %}Disabled{% endif %}"
       disk_encryption_set_id: "{{ byok_des_status.state.id | d(omit) }}"
     network_profile:
       pod_cidr: "{{ pod_cidr | d(omit) }}"
@@ -37,7 +37,7 @@
       client_id: "{{ csp_info.appId | d(omit) }}"
       client_secret: "{{ csp_info.password | d(omit) }}"
     tags:
-      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdby: "{{ currentuser_info.userPrincipalName | default(lookup('env', 'AZURE_CLIENT_ID')) | default('unknown') }}"
       createdwith: ansible
       purge: "true"
     worker_profiles:
@@ -46,7 +46,7 @@
         subnet_id: "{{ worker_subnet_state.state.id }}"
         disk_size: "{{ worker_disk_size | d(omit) }}"
         count: "{{ worker_count | d(omit) }}"
-        encryption_at_host: "{{ worker_encryption_at_host | d(omit) }}"
+        encryption_at_host: "{% if worker_encryption_at_host | d(False) %}Enabled{% else %}Disabled{% endif %}"
         disk_encryption_set_id: "{{ byok_des_status.state.id | d(omit) }}"
   delegate_to: localhost
   register: aro_cluster_state

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
@@ -34,7 +34,7 @@
     subnet_name: jumphost
     managed_disk_type: Standard_LRS
     tags:
-      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdby: "{{ currentuser_info.userPrincipalName | default(lookup('env', 'AZURE_CLIENT_ID')) | default('unknown')}}"
       createdwith: "ansible"
       purge: "true"
     # Use Azure DNS in case this vnet has something else configured

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_resourcegroup.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_resourcegroup.yaml
@@ -19,8 +19,10 @@
   register: signedinuser_output
   ansible.builtin.command:
     argv: ["az", "ad", "signed-in-user", "show", "-o=yaml"]
-  changed_when: false
+  changed_when: signedinuser_output.rc == 0
+  ignore_errors: true
 - name: create_resourcegroup | Set fact currentuser_info
+  when: signedinuser_output is success
   ansible.builtin.set_fact:
     currentuser_info: "{{ signedinuser_output.stdout | from_yaml }}"
 - name: create_resourcegroup | Debug currentuser_info
@@ -32,7 +34,7 @@
     name: "{{ resource_group }}"
     location: "{{ location }}"
     tags:
-      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdby: "{{ currentuser_info.userPrincipalName | default(lookup('env', 'AZURE_CLIENT_ID')) | default('unknown') }}"
       createdwith: "ansible"
       purge: "true"
   delegate_to: localhost

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/create_vnet.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/create_vnet.yaml
@@ -57,7 +57,7 @@
     location: "{{ location }}"
     dns_servers: "{{ dns_servers | default(omit) }}"
     tags:
-      createdby: "{{ currentuser_info.userPrincipalName }}"
+      createdby: "{{ currentuser_info.userPrincipalName | default(lookup('env', 'AZURE_CLIENT_ID')) | default('unknown') }}"
       createdwith: "ansible"
       purge: "true"
   vars:
@@ -88,7 +88,7 @@
         resource_group: "{{ resource_group }}"
         location: "{{ location }}"
         tags:
-          createdby: "{{ currentuser_info.userPrincipalName }}"
+          createdby: "{{ currentuser_info.userPrincipalName | default(lookup('env', 'AZURE_CLIENT_ID')) | default('unknown')}}"
           createdwith: "ansible"
           purge: "true"
       delegate_to: localhost

--- a/update_versions.sh
+++ b/update_versions.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# written by: Microsoft Copilot
+
+
+# Update Python package versions in ansible-requirements.txt
+update_python_packages() {
+    local requirements_file="ansible/ansible-requirements.txt"
+    echo "Updating Python packages in $requirements_file..."
+    while IFS= read -r line; do
+        if [[ $line == *"=="* ]]; then
+            package=$(echo "$line" | cut -d'=' -f1)
+            latest_version=$(pip index versions "$package" 2>/dev/null | grep -oP '(?<=Available versions: ).*' | awk '{print $1}' | sed 's/,//')
+            if [[ -n $latest_version ]]; then
+                echo "Updating $package to version $latest_version"
+                # Remove any trailing commas after the version
+                sed -i "s|$package==.*|$package==$latest_version|" "$requirements_file"
+            else
+                echo "Could not fetch the latest version for $package"
+            fi
+        fi
+    done < "$requirements_file"
+}
+
+# Update version variables in Dockerfile.ansible
+update_dockerfile_versions() {
+    local dockerfile="Dockerfile.ansible"
+    echo "Updating version variables in $dockerfile..."
+
+    declare -A version_sources=(
+        ["PIPX_VERSION"]="pipx"
+        ["ANSIBLE_VERSION"]="ansible"
+        ["AZURE_CLI_VERSION"]="azure-cli"
+        ["ANSIBLE_LINT_VERSION"]="ansible-lint"
+    )
+
+    for var in "${!version_sources[@]}"; do
+        package="${version_sources[$var]}"
+        latest_version=$(pip index versions "$package" 2>/dev/null | grep -oP '(?<=Available versions: ).*' | awk '{print $1}' | sed 's/,//')
+        if [[ -n $latest_version ]]; then
+            echo "Updating $var to $latest_version"
+            # Ensure no trailing commas and add a backslash at the end
+            sed -i "s|ARG $var=.*|ARG $var=$latest_version \\\\|" "$dockerfile"
+        else
+            echo "Could not fetch the latest version for $package"
+        fi
+    done
+
+    # Update ANSIBLE_AZCOLLECTION_VERSION from GalaxyNG (Pulp API)
+    collection="azure/azcollection"
+    api_url="https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/$collection/"
+    response=$(curl -s -w "%{http_code}" -o /tmp/azcollection.json "$api_url")
+    http_code=$(tail -n1 <<< "$response")
+    if [[ $http_code -eq 200 ]]; then
+        latest_collection_version=$(jq -r '.highest_version.version' /tmp/azcollection.json)
+        if [[ -n $latest_collection_version && $latest_collection_version != "null" ]]; then
+            echo "Updating ANSIBLE_AZCOLLECTION_VERSION to $latest_collection_version"
+            sed -i "s|ARG ANSIBLE_AZCOLLECTION_VERSION=.*|ARG ANSIBLE_AZCOLLECTION_VERSION=$latest_collection_version \\\\|" "$dockerfile"
+        else
+            echo "Could not parse the latest version for $collection. Please check the API response."
+        fi
+    else
+        echo "Failed to fetch the latest version for $collection. HTTP code: $http_code"
+        cat /tmp/azcollection.json
+    fi
+}
+
+# Main script execution
+update_python_packages
+update_dockerfile_versions
+
+echo "Update complete!"


### PR DESCRIPTION
**What this PR does / why we need it:**
Partial support for using a local dev RP was added previously as part of MIWI testing. It requires some additional modifications to remove MIWI assumptions and enable ansible to run as part of ARO-RP's docker-compose.

**Does this PR introduce a user-facing change?**
- Update kubernetes python package
- Remove azcli pin of azure-mgmt-rdbms as azcli is once again compatible with the latest package

This also has changes to work with a service principal, needed for Prow jobs.