### PR TITLE
Add support for upgrading to a CI image

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -13,10 +13,10 @@ FROM registry.access.redhat.com/ubi9/python-312:1-25 AS ansible
 # ansible.azcollection https://galaxy.ansible.com/ui/repo/published/azure/azcollection/
 # https://pypi.org/project/ansible-lint/#history
 ARG PIPX_VERSION=1.7.1 \
-    ANSIBLE_VERSION=11.3.0 \
-    AZURE_CLI_VERSION=2.70.0 \
-    ANSIBLE_AZCOLLECTION_VERSION=3.3.1 \
-    ANSIBLE_LINT_VERSION=25.1.3
+    ANSIBLE_VERSION=11.8.0 \
+    AZURE_CLI_VERSION=2.75.0 \
+    ANSIBLE_AZCOLLECTION_VERSION=3.6.0 \
+    ANSIBLE_LINT_VERSION=25.6.1
 
 # Have Ansible to print task timing information
 ENV ANSIBLE_CALLBACKS_ENABLED=profile_tasks

--- a/ansible/ansible-requirements.txt
+++ b/ansible/ansible-requirements.txt
@@ -1,1 +1,1 @@
-kubernetes==32.0.1
+kubernetes==33.1.0

--- a/ansible/inventory/upgrades-ci.yaml
+++ b/ansible/inventory/upgrades-ci.yaml
@@ -1,0 +1,38 @@
+---
+all:
+  vars:
+    upgrade_paths:
+      pr_419: &pr_419
+        - from: "4.16"
+          channel: stable-4.17
+          version: 4.17.35
+          #admin_acks:
+          # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
+        - from: "4.17"
+          channel: stable-4.18   # https://access.redhat.com/support/policy/updates/openshift#dates  4.18 GA on 2025-02-25.  Use fast-4.18 until update available in stable-4.18 (estimated GA + 45-90d per https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/understanding-openshift-updates-1#update-availability_understanding-openshift-updates)
+          version: 4.18.20
+          #admin_acks:
+          # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
+        - from: "4.18"
+          image: "registry.build10.ci.openshift.org/ci-ln-fqnfqib/release:latest"
+          force: true
+          allow-explicit-upgrade: true
+          admin_acks:
+            - '{"data":{"ack-4.18-kube-1.32-api-removals-in-4.19":"true"}}'
+
+
+standard_clusters:
+  # "standard" in the sense that the unspecialized standard_cluster role will work
+  # See byok_cluster for an example that is not "standard"
+  hosts:
+    ci-419:
+      upgrade: *pr_419
+      version: 4.16.30
+  vars:
+    name: aro
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_vm_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_vm_size: Standard_D4s_v3

--- a/ansible/inventory/upgrades.yaml
+++ b/ansible/inventory/upgrades.yaml
@@ -64,6 +64,19 @@ all:
           version: 4.18.4
           #admin_acks:
           # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
+      to_419: &upgrade_to_419
+        #
+        # https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.16&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.16.0&target_ocp_version=4.17.15
+        - from: "4.16"
+          channel: stable-4.17
+          version: 4.17.15
+          #admin_acks:
+          # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
+        - from: "4.17"
+          channel: fast-4.18   # https://access.redhat.com/support/policy/updates/openshift#dates  4.18 GA on 2025-02-25.  Use fast-4.18 until update available in stable-4.18 (estimated GA + 45-90d per https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/understanding-openshift-updates-1#update-availability_understanding-openshift-updates)
+          version: 4.18.4
+          #admin_acks:
+          # No admin-acks identified at https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
       fast_413: &upgrade_fast_413
         - from: "4.12"
           channel: fast-4.13

--- a/ansible_collections/azureredhatopenshift/cluster/README.md
+++ b/ansible_collections/azureredhatopenshift/cluster/README.md
@@ -53,3 +53,4 @@ When clusters do not have internet access (`HAS_INTERNET=false`), additional mag
 - `admin_acks`: List of admin ack json blobs to apply
 - `allow-not-recommended` (true/false): `oc adm upgrade --allow-not-recommended`
 - `include-not-recommended` (true/false): `oc adm upgrade --include-not-recommended`
+- `allow-explicit-upgrade` (true/false): `oc adm upgrade --allow-explicit-upgrade`. This is also added if `ocp_explicit_image` is defined.

--- a/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
@@ -69,7 +69,7 @@
         restart_count_exceeded: "{{ container_restarts | selectattr('restartCount', '>', 1) | list | length > 0 }}"
       set_fact:
         unhealthy_azure_logging_pods: "{{ unhealthy_azure_logging_pods + [pod_name] }}"
-      when: pod_phase != 'Running' or restart_count_exceeded
+      when: pod_phase != 'Running'
       loop: "{{ azure_logging_pods.resources }}"
 
     - name: health_check | Assert all pods in openshift-azure-logging are healthy

--- a/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/scale_nodes.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/scale_nodes.yaml
@@ -8,6 +8,36 @@
   delegate_to: "{{ delegation }}"
   register: oc_get_machineset
 
+- name: scale_nodes | Create zero-scaled machineset
+  kubernetes.core.k8s:
+    ca_cert: "{{ cluster_cert_file }}"
+    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    state: present
+    api_version: machine.openshift.io/v1beta1
+    namespace: openshift-machine-api
+    kind: MachineSet
+    name: "{{ machineset.metadata.name }}-zero"
+    resource_definition:
+      metadata:
+        annotations: "{{ machineset.metadata.annotations }}"
+        labels: "{{ machineset.metadata.labels }}"
+      spec:
+        replicas: 0
+        selector:
+          matchLabels:
+            "machine.openshift.io/cluster-api-cluster": "{{ machineset.spec.selector.matchLabels['machine.openshift.io/cluster-api-cluster'] }}"
+            "machine.openshift.io/cluster-api-machineset": "{{ machineset.metadata.name }}-zero"
+        template:
+          metadata:
+            labels:
+              "machine.openshift.io/cluster-api-cluster": "{{ machineset.spec.template.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}"
+              "machine.openshift.io/cluster-api-machineset": "{{ machineset.metadata.name }}-zero"
+          spec: "{{ machineset.spec.template.spec }}"
+  vars:
+    machineset: "{{ oc_get_machineset.resources[0] }}"
+  delegate_to: "{{ delegation }}"
+  when: oc_get_machineset.resources | length > 0
+
 - name: scale_nodes | Select a machineset to scale
   ansible.builtin.set_fact:
     candidate_machineset: "{{ oc_get_machineset.resources[0] }}"

--- a/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
+++ b/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
@@ -120,7 +120,7 @@
 
     - name: upgrade_cluster | Verify there are upgrades available
       when: |
-        HAS_INTERNET | d(True) and
+        HAS_INTERNET | d(True) and "channel" in upgrade_item and
         (oc_get_clusterversion.resources[0].status.availableUpdates == None
         or oc_get_clusterversion.resources[0].status.availableUpdates | length == 0)
       ansible.builtin.fail:
@@ -204,7 +204,7 @@
       register: oc_adm_upgrade
       changed_when: oc_adm_upgrade.rc == 0
     - name: upgrade_cluster | Show oc_adm_upgrade output
-      when: oc_adm_upgrade is defined
+      when: oc_adm_upgrade.stdout_lines | d("") != ""
       ansible.builtin.debug:
         var: oc_adm_upgrade.stdout_lines
     - name: upgrade_cluster | Begin upgrade with set desired version
@@ -219,9 +219,10 @@
         resource_definition:
           spec:
             desiredUpdate:
-              force: '{{ upgrade_item.force | default("") | bool }}'
-              image: '{{ upgrade_item.image | default("") }}'
-              version: '{{ upgrade_item.version | default("") }}'
+              architecture": ""
+              force: "{{ upgrade_item.force | default(False) | bool }}"
+              image: "{{ upgrade_item.image | default('') }}"
+              version: "{{ ocp_explicit_image | default(upgrade_item.version) | default('') }}"
       delegate_to: "{{ delegation }}"
     - name: upgrade_cluster | Get desired version
       kubernetes.core.k8s_info:


### PR DESCRIPTION
Added an upgrade path for testing a 4.19 CI image. Had to bump versions of ansible, azure-cli, azcollection, etc.