### PR TITLE
Changes to support prow

### DIFF
--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
@@ -1,7 +1,7 @@
 - name: health_check | Get ARO cluster operator
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: config.openshift.io/v1
     kind: ClusterOperator
     name: aro
@@ -10,7 +10,7 @@
 - name: health_check | Get ARO deployment aro-operator-master
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: apps/v1
     kind: Deployment
     name: aro-operator-master
@@ -19,7 +19,7 @@
 - name: health_check | Get ARO deployment aro-operator-worker
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: apps/v1
     kind: Deployment
     name: aro-operator-worker
@@ -48,7 +48,7 @@
       # Fetch all pod objects from the openshift-azure-logging namespace
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: v1
         kind: Pod
         namespace: openshift-azure-logging
@@ -117,7 +117,7 @@
       # Retrieve alertmanager pods in the openshift-monitoring namespace
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: v1
         kind: Pod
         namespace: openshift-monitoring
@@ -130,7 +130,7 @@
       # Use 'amtool' inside the first Alertmanager pod to list all currently firing alerts
       kubernetes.core.k8s_exec:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         namespace: openshift-monitoring
         pod: "{{ alertmanager_pods.resources[0].metadata.name }}"
         command: "/usr/bin/amtool --alertmanager.url=http://localhost:9093 alert --output=json"

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/new_project.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/new_project.yaml
@@ -10,14 +10,14 @@
           - oc
           - project
           - default
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       delegate_to: "{{ delegation }}"
       changed_when: false
 
     - name: new_project | Get nginx service
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: v1
         namespace: default
         kind: Service
@@ -35,7 +35,7 @@
           - delete
           - service,deployment,imagestream
           - nginx
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       delegate_to: "{{ delegation }}"
       register: delete_nginx
       changed_when: delete_nginx.rc == 0
@@ -43,7 +43,7 @@
     - name: new_project | Get nginx route
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: route.openshift.io/v1
         namespace: default
         kind: Route
@@ -61,7 +61,7 @@
           - delete
           - route
           - nginx
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       delegate_to: "{{ delegation }}"
       register: delete_route
       changed_when: delete_route.rc == 0
@@ -74,7 +74,7 @@
           - oc
           - new-app
           - --image=nginx
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       delegate_to: "{{ delegation }}"
       register: new_app_nginx
       changed_when: new_app_nginx.rc == 0
@@ -86,7 +86,7 @@
           - oc
           - expose
           - svc/nginx
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       delegate_to: "{{ delegation }}"
       register: expose_nginx
       changed_when: expose_nginx.rc == 0
@@ -98,7 +98,7 @@
           - oc
           - get
           - deployment,pod,route,service
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       register: oc_get_nginx_deployment_pod_route_service
       delegate_to: "{{ delegation }}"
       changed_when: oc_get_nginx_deployment_pod_route_service.rc == 0
@@ -108,7 +108,7 @@
     - name: new_project | Get nginx service
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: route.openshift.io/v1
         namespace: default
         kind: Route
@@ -123,7 +123,7 @@
     - name: new_project | Create nginx Deployment
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: apps/v1
         namespace: default
         kind: Deployment
@@ -151,7 +151,7 @@
     - name: new_project | Create nginx-lb lb Service
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: v1
         namespace: default
         kind: Service

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/provision_pvs.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/provision_pvs.yaml
@@ -1,7 +1,7 @@
 - name: provision_pvs | Provision azurefile-csi PVC
   kubernetes.core.k8s:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     namespace: default
     kind: PersistentVolumeClaim
@@ -24,7 +24,7 @@
 - name: provision_pvs | Provision managed-csi PVC
   kubernetes.core.k8s:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     namespace: default
     kind: PersistentVolumeClaim
@@ -47,7 +47,7 @@
 - name: provision_pvs | Provision managed-csi-encrypted-cmk PVC
   kubernetes.core.k8s:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     namespace: default
     kind: PersistentVolumeClaim

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/refresh_credentials.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/refresh_credentials.yaml
@@ -11,6 +11,8 @@
   register: oc_get_azure_credentials
 - name: refresh_credentials | Az aro update refresh-credentials
   ansible.builtin.command:
+    argv: "{{ argv | reject('equalto', omit) | list }}"
+  vars:
     argv:
       - az
       - aro

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/refresh_credentials.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/refresh_credentials.yaml
@@ -2,7 +2,7 @@
 - name: refresh_credentials | Get original secret/azure-credentials
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     kind: Secret
     name: azure-credentials
@@ -37,7 +37,7 @@
 - name: refresh_credentials | Get new secret/azure-credentials
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     kind: Secret
     name: azure-credentials

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/scale_nodes.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/scale_nodes.yaml
@@ -1,7 +1,7 @@
 - name: scale_nodes | Get machinesets
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: machine.openshift.io/v1beta1
     namespace: openshift-machine-api
     kind: MachineSet
@@ -11,7 +11,7 @@
 - name: scale_nodes | Create zero-scaled machineset
   kubernetes.core.k8s:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     state: present
     api_version: machine.openshift.io/v1beta1
     namespace: openshift-machine-api
@@ -48,7 +48,7 @@
 - name: scale_nodes | Scale down machineset
   kubernetes.core.k8s:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     state: patched
     api_version: machine.openshift.io/v1beta1
     namespace: openshift-machine-api
@@ -65,7 +65,7 @@
 - name: scale_nodes | Wait for scale down
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: machine.openshift.io/v1beta1
     namespace: openshift-machine-api
     kind: MachineSet
@@ -79,7 +79,7 @@
 - name: scale_nodes | Scale up machineset
   kubernetes.core.k8s:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     state: patched
     api_version: machine.openshift.io/v1beta1
     namespace: openshift-machine-api
@@ -96,7 +96,7 @@
 - name: scale_nodes | Wait for scale up
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: machine.openshift.io/v1beta1
     namespace: openshift-machine-api
     kind: MachineSet

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -274,7 +274,7 @@
   delegate_to: localhost
   retries: 6 # Retry because it might need to propagate.
   delay: 60
-  no_log: true
+  # no_log: true
 
 - name: create_aro_cluster | Update fact csp_info with password
   when: csp_info is defined and sp_password_result is success
@@ -284,7 +284,7 @@
       displayName: "{{ csp_info.displayName | d(omit) }}"
       password: "{{ sp_password_result.secret_text }}"
       password_key_id: "{{ sp_password_result.key_id }}"
-  no_log: true
+  # no_log: true
 
 - name: create_aro_cluster | Prepare pull secret
   ansible.builtin.include_tasks:

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -183,7 +183,27 @@
 - name: create_aro_cluster | Custom service principal
   when: create_csp | d(False)
   block:
+    - name: create_aro_cluster | Get existing AD Application
+      azure.azcollection.azure_rm_adapplication_info:
+        app_display_name: "{{ cluster_name }}-{{ resource_group }}-sp"
+      delegate_to: localhost
+      register: ad_app_info
+    - name: create_aro_cluster | Show existing AD Service Principal
+      azure.azcollection.azure_rm_adserviceprincipal_info:
+        app_id: "{{ ad_app_info.applications[0].app_id }}"
+      delegate_to: localhost
+      register: ad_sp_info
+      when: ad_app_info.applications | length > 0
+    - name: create_aro_cluster | Set fact csp_info from existing service principal
+      when: ad_app_info.applications | length > 0 and ad_sp_info.service_principals | length > 0
+      ansible.builtin.set_fact:
+        csp_info:
+          appId: "{{ ad_app_info.applications[0].app_id }}"
+          objectId: "{{ ad_app_info.applications[0].object_id }}"
+          displayName: "{{ ad_app_info.applications[0].app_display_name }}"
+      no_log: true
     - name: create_aro_cluster | Create Azure AD Application
+      when: ad_app_info.applications | length == 0
       azure.azcollection.azure_rm_adapplication:
         display_name: "{{ cluster_name }}-{{ resource_group }}-sp"
         state: present
@@ -196,6 +216,7 @@
         var: ad_app
         verbosity: 2
     - name: create_aro_cluster | Create Service Principal for the Application
+      when: ad_app is changed
       azure.azcollection.azure_rm_adserviceprincipal:
         app_id: "{{ ad_app.app_id }}"
         state: present
@@ -203,38 +224,56 @@
       register: ad_sp
       retries: 3 # Retry because it might need to propagate
       delay: 60
-    - name: create_aro_cluster | Show application
+    - name: create_aro_cluster | Show Service Principal
       ansible.builtin.debug:
         var: ad_sp
         verbosity: 2
     - name: create_aro_cluster | Assign Contributor Role to the Service Principal
+      when: ad_sp is changed
       azure.azcollection.azure_rm_roleassignment:
         scope: "/subscriptions/{{ sub_info.subscription_id }}/resourceGroups/{{ resource_group }}"
         assignee_object_id: "{{ ad_sp.object_id }}"
-        # Contributor: b24988ac-6180-42a0-ab88-20f7382dd24c
+        # "Contributor" is b24988ac-6180-42a0-ab88-20f7382dd24c
         role_definition_id: "/subscriptions/{{ sub_info.subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
         state: present
       delegate_to: localhost
       retries: 3 # Retry because it might need to propagate
       delay: 60
     - name: create_aro_cluster | Update fact csp_info
+      when: ad_app is changed
       ansible.builtin.set_fact:
         csp_info:
           appId: "{{ ad_app.app_id }}"
+          objectId: "{{ ad_app.object_id }}"
           displayName: "{{ ad_app.display_name }}"
       no_log: true
 
+- debug: var=csp_info
+
+- name: Clear Service Principal Password
+  when: csp_info is defined and "password" not in csp_info
+  azure.azcollection.azure_rm_adpassword:
+    # This ansible module can only set the first password, so we delete all existing passwords first
+    app_id: "{{ csp_info.appId }}"
+    app_object_id: "{{ csp_info.objectId | default(omit) }}"
+    state: absent
+  retries: 30 # This will often fail wth "Error due to concurrent requests being made to the tenant. Please wait briefly and retry" if there are multiple passwords to clear
+  delay: 5
+  delegate_to: localhost
 - name: Create or Update Service Principal Password
   when: csp_info is defined and "password" not in csp_info
   azure.azcollection.azure_rm_adpassword:
-    app_id: "{{ ad_app.app_id }}"
-    display_name: "{{ cluster_name }}-{{ resource_group }}-sp-password"
+    app_id: "{{ csp_info.appId }}"
+    app_object_id: "{{ csp_info.objectId | default(omit) }}"
+    display_name: "{{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%S.%fZ') }}"
+    state: present
   register: sp_password_result
+  # This will frequently set a password but fail to return it. Fail when we don't get the password back, and retry
   failed_when: sp_password_result.secret_text | d('') == ''
   delegate_to: localhost
-  retries: 3 # Retry because it might need to propagate
+  retries: 6 # Retry because it might need to propagate.
   delay: 60
-  no_log: true
+  # no_log: true
 
 - name: create_aro_cluster | Update fact csp_info with password
   when: csp_info is defined and sp_password_result is success
@@ -244,7 +283,7 @@
       displayName: "{{ csp_info.displayName | d(omit) }}"
       password: "{{ sp_password_result.secret_text }}"
       password_key_id: "{{ sp_password_result.key_id }}"
-  no_log: true
+  # no_log: true
 
 - name: create_aro_cluster | Prepare pull secret
   ansible.builtin.include_tasks:
@@ -264,6 +303,27 @@
     aro_cluster_create_wait.clusters.properties.provisioningState | d ("") == "Creating"
     or aro_cluster_create_wait.clusters.properties.provisioningState | d ("") == "Deleting"
   retries: 60
+  delay: 60
+
+- name: refresh_credentials | Apply new service principal to existing cluster
+  when: csp_info is defined and aro_cluster_create_wait.clusters.properties.provisioningState | d("") == "Succeeded"
+  ansible.builtin.command:
+    argv: "{{ argv | reject('equalto', omit) | list }}"
+  vars:
+    argv:
+      - az
+      - aro
+      - update
+      - --name={{ cluster_name }}
+      - --resource-group={{ resource_group }}
+      - --client-secret={{ csp_info.password }}
+      - --client-id={{ csp_info.appId }}
+      - -o=yaml
+  delegate_to: localhost
+  register: az_aro_update
+  changed_when: az_aro_update.rc == 0
+  # FIXME: Need to investigate why this occasionally fails with InternalServerError
+  retries: 3
   delay: 60
 
 - name: create_aro_cluster | Create cluster via module
@@ -430,8 +490,8 @@
 
 - name: create_aro_cluster | Kubeconfig file name
   ansible.builtin.set_fact:
-    kubeconfig_filename: "/tmp/{{ kubeconfig_filename }}"
-    kubeconfig_tmp: "/tmp/{{ kubeconfig_filename }}.tmp"
+    kubeconfig_filename: "/tmp/{{ cluster_name }}-{{ resource_group }}.kubeconfig"
+    kubeconfig_tmp: "/tmp/{{ cluster_name }}-{{ resource_group }}.kubeconfig.tmp"
 
 - name: create_aro_cluster | Get new cluster kubeconfig content
   ansible.builtin.command:

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -1,4 +1,8 @@
 ---
+- name: create_jumphost | Set ansible private key file
+  ansible.builtin.set_fact:
+    ansible_ssh_private_key_file: "/root/.ssh/{{ SSH_KEY_BASENAME }}.pub"
+
 - name: create_aro_cluster | Set up a jumphost for private clusters
   when: apiserver_visibility | d("Public") == "Private"
   ansible.builtin.include_tasks:
@@ -218,22 +222,19 @@
         csp_info:
           appId: "{{ ad_app.app_id }}"
           displayName: "{{ ad_app.display_name }}"
-      # no_log: true
-    - debug: var=csp_info
+      no_log: true
 
 - name: Create or Update Service Principal Password
-  # When the playbook specifies an existing SP, and we don't have a password, create one
   when: csp_info is defined and "password" not in csp_info
   azure.azcollection.azure_rm_adpassword:
     app_id: "{{ ad_app.app_id }}"
     display_name: "{{ cluster_name }}-{{ resource_group }}-sp-password"
   register: sp_password_result
+  failed_when: sp_password_result.secret_text | d('') == ''
   delegate_to: localhost
   retries: 3 # Retry because it might need to propagate
   delay: 60
-  # no_log: true
-
-- debug: var=sp_password_result
+  no_log: true
 
 - name: create_aro_cluster | Update fact csp_info with password
   when: csp_info is defined and sp_password_result is success
@@ -243,7 +244,7 @@
       displayName: "{{ csp_info.displayName | d(omit) }}"
       password: "{{ sp_password_result.secret_text }}"
       password_key_id: "{{ sp_password_result.key_id }}"
-  # no_log: true
+  no_log: true
 
 - name: create_aro_cluster | Prepare pull secret
   ansible.builtin.include_tasks:
@@ -427,6 +428,11 @@
   register: az_vm_runcommand_jumphost
   changed_when: az_vm_runcommand_jumphost.rc == 0
 
+- name: create_aro_cluster | Kubeconfig file name
+  ansible.builtin.set_fact:
+    kubeconfig_filename: "/tmp/{{ kubeconfig_filename }}"
+    kubeconfig_tmp: "/tmp/{{ kubeconfig_filename }}.tmp"
+
 - name: create_aro_cluster | Get new cluster kubeconfig content
   ansible.builtin.command:
     argv:
@@ -436,7 +442,7 @@
       - "--name={{ cluster_name }}"
       - "--resource-group={{ resource_group }}"
       - "-f"
-      - "{{ inventory_hostname }}.kubeconfig.tmp"
+      - "{{ kubeconfig_tmp }}"
   environment:
     RP_MODE: development
   delegate_to: localhost
@@ -445,7 +451,7 @@
 
 - name: create_aro_cluster | Read new kubeconfig from temp file
   ansible.builtin.slurp:
-    src: "{{ inventory_hostname }}.kubeconfig.tmp"
+    src: "{{ kubeconfig_tmp }}"
   delegate_to: localhost
   register: new_kubeconfig_slurp
   changed_when: false
@@ -457,20 +463,20 @@
 
 - name: create_aro_cluster | Delete temp kubeconfig file
   ansible.builtin.file:
-    path: "{{ inventory_hostname }}.kubeconfig.tmp"
+    path: "{{ kubeconfig_tmp }}"
     state: absent
   delegate_to: localhost
   changed_when: false
 
-- name: create_aro_cluster | Check if {{ inventory_hostname }}.kubeconfig already exists
+- name: create_aro_cluster | Check if kubeconfig already exists
   ansible.builtin.stat:
-    path: "{{ inventory_hostname }}.kubeconfig"
+    path: "{{ kubeconfig_filename }}"
   delegate_to: localhost
   register: kubeconfig_stat
 
 - name: create_aro_cluster | Read (old) existing kubeconfig file
   ansible.builtin.slurp:
-    src: "{{ inventory_hostname }}.kubeconfig"
+    src: "{{ kubeconfig_filename }}"
   when: kubeconfig_stat.stat.exists
   delegate_to: localhost
   register: existing_kubeconfig_slurp
@@ -489,8 +495,8 @@
   ansible.builtin.command:
     argv:
       - mv
-      - "{{ inventory_hostname }}.kubeconfig"
-      - "{{ inventory_hostname }}.kubeconfig.{{ now(utc=True, fmt='%Y%m%d%H%M%S') }}.bkp"
+      - "{{ kubeconfig_filename }}"
+      - "{{ kubeconfig_filename }}.~{{ now(utc=True, fmt='%Y%m%d%H%M%S') }}~"
   when: kubeconfig_stat.stat.exists and kubeconfig_changed
   delegate_to: localhost
   changed_when: true
@@ -498,7 +504,7 @@
 - name: create_aro_cluster | Write new kubeconfig file
   ansible.builtin.copy:
     content: "{{ new_kubeconfig_content }}"
-    dest: "{{ inventory_hostname }}.kubeconfig"
+    dest: "{{ kubeconfig_filename }}"
   when: kubeconfig_changed
   delegate_to: localhost
   changed_when: true
@@ -506,8 +512,8 @@
 - name: create_aro_cluster | Copy cluster kubeconfig to jumphost
   when: delegation != "localhost"
   ansible.builtin.copy:
-    src: "{{ inventory_hostname }}.kubeconfig"
-    dest: "{{ inventory_hostname }}.kubeconfig"
+    src: "{{ kubeconfig_filename }}"
+    dest: "{{ kubeconfig_filename }}"
     mode: "0644"
   delegate_to: "{{ delegation }}"
 
@@ -561,7 +567,7 @@
 
 - name: create_aro_cluster | Get apiserver configuration
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: config.openshift.io/v1
     kind: APIServer
     name: cluster
@@ -577,7 +583,7 @@
   # NOTE: miwi doesn't have this, why? It only has "spec": {"audit": {"profile": "Default"}}
   when: "apiserver_cluster.resources[0].spec.servingCerts.namedCertificates[0].servingCertificate.name | d('') != ''"
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     namespace: openshift-config
     kind: Secret
@@ -682,7 +688,7 @@
     - name: create_aro_cluster | Get clusterversion version
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: config.openshift.io/v1
         kind: ClusterVersion
         name: version
@@ -715,7 +721,7 @@
       when: ocp_explicit_image_sig is defined
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: v1
         kind: ConfigMap
         namespace: openshift-config-managed
@@ -738,7 +744,7 @@
 - name: create_aro_cluster | Wait for clusterversion to become Available and not Progressing
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: config.openshift.io/v1
     kind: ClusterVersion
     name: version
@@ -760,7 +766,7 @@
 - name: create_aro_cluster | Get cluster operators
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: config.openshift.io/v1
     kind: ClusterOperator
   delegate_to: "{{ delegation }}"
@@ -783,7 +789,7 @@
   - name: create_aro_cluster | Wait for cluster operators to stop progressing
     kubernetes.core.k8s_info:
       ca_cert: "{{ cluster_cert_file }}"
-      kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+      kubeconfig: "{{ kubeconfig_filename }}"
       api_version: config.openshift.io/v1
       kind: ClusterOperator
     delegate_to: "{{ delegation }}"
@@ -828,7 +834,7 @@
 - name: create_aro_cluster | Get nodes
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     kind: Node
   delegate_to: "{{ delegation }}"
@@ -875,7 +881,7 @@
 - name: create_aro_cluster | Get cluster operators
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: config.openshift.io/v1
     kind: ClusterOperator
   delegate_to: "{{ delegation }}"
@@ -932,7 +938,7 @@
     argv:
       - oc
       - version
-      - --kubeconfig={{ inventory_hostname }}.kubeconfig
+      - --kubeconfig={{ kubeconfig_filename }}
   delegate_to: "{{ delegation }}"
   register: oc_version
   changed_when: oc_version.rc == 0
@@ -949,7 +955,7 @@
     - name: create_aro_cluster | Get cluster.aro/cluster
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         name: cluster
         api_version: aro.openshift.io/v1alpha1
         kind: Cluster
@@ -962,7 +968,7 @@
     - name: create_aro_cluster | Configure cluster wide proxy
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         name: cluster
         api_version: config.openshift.io/v1
         kind: Proxy
@@ -991,7 +997,7 @@
 
 - name: create_aro_cluster | Create machineconfig to enable ssh access
   kubernetes.core.k8s:
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: v1
     kind: MachineConfig
     name: 99-ssh-access

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -250,16 +250,17 @@
 
 - debug: var=csp_info
 
-- name: Clear Service Principal Password
-  when: csp_info is defined and "password" not in csp_info
-  azure.azcollection.azure_rm_adpassword:
-    # This ansible module can only set the first password, so we delete all existing passwords first
-    app_id: "{{ csp_info.appId }}"
-    app_object_id: "{{ csp_info.objectId | default(omit) }}"
-    state: absent
-  retries: 30 # This will often fail wth "Error due to concurrent requests being made to the tenant. Please wait briefly and retry" if there are multiple passwords to clear
-  delay: 5
-  delegate_to: localhost
+# - name: Clear Service Principal Password
+#   when: csp_info is defined and "password" not in csp_info
+#   azure.azcollection.azure_rm_adpassword:
+#     # This ansible module doesn't reliably return the set password,
+#     # so clear existing passwords so they don't pile up
+#     app_id: "{{ csp_info.appId }}"
+#     app_object_id: "{{ csp_info.objectId | default(omit) }}"
+#     state: absent
+#   retries: 30 # This will often fail wth "Error due to concurrent requests being made to the tenant. Please wait briefly and retry" if there are multiple passwords to clear
+#   delay: 5
+#   delegate_to: localhost
 - name: Create or Update Service Principal Password
   when: csp_info is defined and "password" not in csp_info
   azure.azcollection.azure_rm_adpassword:
@@ -273,7 +274,7 @@
   delegate_to: localhost
   retries: 6 # Retry because it might need to propagate.
   delay: 60
-  # no_log: true
+  no_log: true
 
 - name: create_aro_cluster | Update fact csp_info with password
   when: csp_info is defined and sp_password_result is success
@@ -283,7 +284,7 @@
       displayName: "{{ csp_info.displayName | d(omit) }}"
       password: "{{ sp_password_result.secret_text }}"
       password_key_id: "{{ sp_password_result.key_id }}"
-  # no_log: true
+  no_log: true
 
 - name: create_aro_cluster | Prepare pull secret
   ansible.builtin.include_tasks:

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_jumphost.yaml
@@ -11,9 +11,6 @@
     var: jumphost_subnet_state
     verbosity: 1
 
-- name: create_jumphost | Set ansible private key file
-  ansible.builtin.set_fact:
-    ansible_ssh_private_key_file: "/root/.ssh/{{ SSH_KEY_BASENAME }}.pub"
 - name: create_jumphost | Create jumphost vm
   azure.azcollection.azure_rm_virtualmachine:
     name: jumphost

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
@@ -8,7 +8,7 @@
 - name: upgrade_cluster | Get clusterversion
   kubernetes.core.k8s_info:
     ca_cert: "{{ cluster_cert_file }}"
-    kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+    kubeconfig: "{{ kubeconfig_filename }}"
     api_version: config.openshift.io/v1
     kind: ClusterVersion
     name: version
@@ -69,7 +69,7 @@
       when: ocp_explicit_image is defined and ocp_explicit_image_sig is defined
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: v1
         kind: ConfigMap
         namespace: openshift-config-managed
@@ -85,7 +85,7 @@
       when: HAS_INTERNET | d(True) and "channel" in upgrade_item
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         state: patched
         api_version: config.openshift.io/v1
         kind: ClusterVersion
@@ -99,7 +99,7 @@
       when: HAS_INTERNET | d(True)
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: config.openshift.io/v1
         kind: ClusterVersion
         name: version
@@ -131,7 +131,7 @@
       loop: "{{ upgrade_item.admin_acks }}"
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         state: patched
         merge_type: merge
         api_version: v1
@@ -144,7 +144,7 @@
     - name: upgrade_cluster | Wait for cluster to be upgradeable
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: config.openshift.io/v1
         kind: ClusterVersion
         name: version
@@ -172,7 +172,7 @@
           - oc
           - adm
           - upgrade
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       register: oc_adm_upgrade_channel
       delegate_to: "{{ delegation }}"
       changed_when: false
@@ -199,7 +199,7 @@
           - '{% if upgrade_item.get("allow-not-recommended", False) %}--allow-not-recommended{% else %}{{ omit }}{% endif %}'
           - '{% if upgrade_item.get("include-not-recommended", False) %}--include-not-recommended{% else %}{{ omit }}{% endif %}'
           - '{% if upgrade_item.get("allow-explicit-upgrade", False) or ocp_explicit_image is defined %}--allow-explicit-upgrade{% else %}{{ omit }}{% endif %}'
-          - --kubeconfig={{ inventory_hostname }}.kubeconfig
+          - --kubeconfig={{ kubeconfig_filename }}
       delegate_to: "{{ delegation }}"
       register: oc_adm_upgrade
       changed_when: oc_adm_upgrade.rc == 0
@@ -211,7 +211,7 @@
       when: upgrade_item.use_cli | default(False) == False
       kubernetes.core.k8s:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: config.openshift.io/v1
         state: patched
         kind: ClusterVersion
@@ -227,7 +227,7 @@
     - name: upgrade_cluster | Get desired version
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: config.openshift.io/v1
         kind: ClusterVersion
         name: version
@@ -244,7 +244,7 @@
     - name: upgrade_cluster | Wait for upgrade to complete
       kubernetes.core.k8s_info:
         ca_cert: "{{ cluster_cert_file }}"
-        kubeconfig: "{{ inventory_hostname }}.kubeconfig"
+        kubeconfig: "{{ kubeconfig_filename }}"
         api_version: config.openshift.io/v1
         kind: ClusterVersion
         name: version


### PR DESCRIPTION
Various changes to support the prow environment:
 - write kubeconfig file to /tmp instead of $HOME
 - avoid creating duplicate service principals
 - retry setting the service principal password
 - set no_log on tasks that may print service principal information