### PR TITLE
Can't chown root in prow

### DIFF
--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -988,8 +988,6 @@
     dest: "{{ oc_bin_file | dirname }}"
     include: ["oc"]
     mode: "0755"
-    owner: root
-    group: root
     validate_certs: "{% if rp_mode | d('production') == 'development' %}false{% else %}{{ omit }}{% endif %}"
   become: "{{ delegation != 'localhost' }}"
   delegate_to: "{{ delegation }}"
@@ -999,8 +997,6 @@
     dest: "{{ oc_bin_file }}"
     state: hard
     mode: "0755"
-    owner: root
-    group: root
   delegate_to: "{{ delegation }}"
 - name: create_aro_cluster | Get oc version
   ansible.builtin.command:


### PR DESCRIPTION
Prow fails with `chown failed: [Errno 1] Operation not permitted: b'/tmp/oc'`, so we will avoid setting owner and group in order to use the current user and group.