### PR TITLE
fix: migrate base image from registry.access.redhat.com to registry.redhat.io

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -1,10 +1,11 @@
 ###############################################################################
 # ansible is the base Python image with ansible and azure-cli
 ###############################################################################
-FROM registry.access.redhat.com/ubi9/python-312:1-25 AS ansible
+ARG REGISTRY=registry.redhat.io
+FROM ${REGISTRY}/ubi9/python-312:1-25 AS ansible
 # Versions
-# python-311 container:
-#   $ skopeo list-tags docker://registry.access.redhat.com/ubi9/python-312 | jq '.Tags[] | select(test("^[0-9]-[0-9]+$"))' | tail -n 1
+# python-312 container:
+#   $ skopeo list-tags docker://registry.redhat.io/ubi9/python-312 | jq '.Tags[] | select(test("^[0-9]-[0-9]+$"))' | tail -n 1
 # Check azure-cli release notes to see if it supports a newer Python:
 #   https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli
 # pipx https://pypi.org/project/pipx/#history


### PR DESCRIPTION
## Summary

`registry.access.redhat.com` has been retired by Red Hat. The
`Dockerfile.ansible` base image pull now fails with connection refused.

This PR adds `ARG REGISTRY=registry.redhat.io` to the Dockerfile so
the registry is configurable, defaulting to the current supported
registry. The stale `python-311` comment is also corrected to
`python-312`.

`registry.redhat.io` requires authentication (`podman login`) before
building. This does not affect Prow CI, which does not reference
`Dockerfile.ansible`.

## References

- [Transitioning the Red Hat container registry](https://www.redhat.com/en/blog/transitioning-red-hat-container-registry)
- [Red Hat Container Registry Authentication](https://access.redhat.com/articles/RegistryAuthentication)
- [Firewall changes for container image pulls 2024/2025](https://access.redhat.com/articles/7084334)

## CI impact

None. Prow CI does not build `Dockerfile.ansible`.

## Test plan

- `podman login registry.redhat.io` with Red Hat credentials
- `make ansible-image` builds successfully
- `REGISTRY=registry.redhat.io make ansible-image` (explicit override) also works