### PR TITLE
Suppress sensitive values from Ansible task output

### DIFF
--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -322,6 +322,7 @@
 
 - name: create_aro_cluster | Apply new service principal to existing cluster
   when: csp_info is defined and aro_cluster_create_wait.clusters.properties.provisioningState | d("") == "Succeeded"
+  no_log: true
   ansible.builtin.command:
     argv: "{{ argv | reject('equalto', omit) | list }}"
   vars:

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_cluster_azcli.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_cluster_azcli.yaml
@@ -14,6 +14,7 @@
     verbosity: 1
 - name: create_cluster_azcli | Create aro cluster
   when: aro_cluster_state.clusters.id | d("") == ""
+  no_log: true
   ansible.builtin.command:
     argv: "{{ (argv + cluster_extra_args | d([])) | reject('equalto', omit) | list }}"
   vars:
@@ -58,7 +59,7 @@
   delegate_to: localhost
 - name: create_cluster_azcli | Show az aro create command line
   ansible.builtin.debug:
-    msg: "{{ az_aro_create_output.get('cmd', []) | join(' ') }}"
+    msg: "{{ az_aro_create_output.get('cmd', []) | map('regex_replace', '--client-secret=.*', '--client-secret=REDACTED') | join(' ') }}"
 - name: create_cluster_azcli | Check az aro create output
   when: 'az_aro_create_output is defined and "ERROR:" in az_aro_create_output.get("stderr", "")'
   ansible.builtin.fail:


### PR DESCRIPTION
## Summary
- Add `no_log: true` to `az aro create` and `az aro update` command tasks that pass credentials on the command line
- Redact credential arguments in the debug task that prints the command line

## Test plan
- [ ] Verify `az aro create` task output no longer shows sensitive values
- [ ] Verify debug task prints the command with `--client-secret=REDACTED`
- [ ] Verify `az aro update` task output no longer shows sensitive values

🤖 Generated with [Claude Code](https://claude.com/claude-code)