### PR TITLE
Udr421

### DIFF
--- a/Dockerfile.ansible.constraints
+++ b/Dockerfile.ansible.constraints
@@ -1,2 +1,6 @@
 azure-cli!=2.77.0 # https://github.com/Azure/azure-cli/issues/32101
 azure-cli!=2.78.0 # https://github.com/Azure/azure-cli/issues/32258
+# cryptography>=44 crashes with "Illegal instruction" (SIGILL) when running
+# ansible-galaxy on some virtualized arm64 hosts (e.g. Podman machine on
+# Apple Silicon). Pin to a version confirmed to work until upstream fixes it.
+cryptography==43.0.3

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ PODMAN_VOLUME_OVERLAY=$(shell if [[ $$(getenforce) == "Enforcing" ]]; then echo 
 .PHONY: ansible-image
 ansible-image:
 	python3 ./utils/build-ansible-image.py Dockerfile.ansible \
+		--podman-remote-args "$(PODMAN_REMOTE_ARGS)" \
 		--build-arg REGISTRY=$(REGISTRY) \
 		--build-arg VERSION=$(VERSION) \
 		--tag aro-ansible:$(VERSION) \
@@ -114,6 +115,7 @@ ansible-image:
 .PHONY: ansible-image-latest
 # ansible-image-latest:
 # 	python3 ./utils/build-ansible-image.py Dockerfile.ansible --latest \
+# 		--podman-remote-args "$(PODMAN_REMOTE_ARGS)" \
 # 		--build-arg REGISTRY=$(REGISTRY) \
 # 		--build-arg VERSION=$(VERSION) \
 # 		--tag aro-ansible:$(VERSION) \

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/defaults/main.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/defaults/main.yaml
@@ -6,7 +6,12 @@
 # * Environment vars passed via Makefile
 # * Vars defined in playbooks, inventory, or host/group vars
 
-# health_check | Filter firing alerts based on severity:
+# health_check | Filter firing alerts based on severity and expected alerts:
 smoketest_ignored_alert_severities:
   - none
   - info
+
+# Alertname allowlist for alerts that are expected to fire on a given cluster
+# (e.g. CoreDNSErrorsHigh on clusters with deliberately broken DNS). Override
+# per-cluster in inventory.
+expected_alertmanager_alerts: []

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
@@ -66,30 +66,34 @@
         pod_phase: "{{ item.status.phase | d('Unknown') }}"
         container_restarts: "{{ item.status.containerStatuses | d([]) }}"
         restart_count_exceeded: "{{ container_restarts | selectattr('restartCount', '>', 1) | list | length > 0 }}"
+        # This template mixes literal "[" "]" text with control blocks, so Ansible
+        # renders it as a plain JSON string rather than a native list. Parse it with
+        # from_json below so `loop` gets an actual list.
+        azure_logging_pods_json: |-
+          {% set comma = joiner(',') %}
+          [
+          {% for item in smoketest_azure_logging_pods.resources -%}
+            {{ comma() -}}
+            {
+              "metadata": { "name": "{{ item.metadata.name }}" },
+              "status": {
+                "phase": "{{ item.status.phase }}",
+                "containerStatuses": [{% for i in item.status.containerStatuses | d([]) -%}
+                  {
+                      "name": "{{ i.name }}",
+                      "ready": "{{ i.ready }}",
+                      "restartCount": {{ i.restartCount }}
+                  }{{ "," if not loop.last else "" }}
+                {% endfor -%}
+                ]
+              }
+            }{% endfor -%}
+          ]
       ansible.builtin.set_fact:
         smoketest_unhealthy_azure_logging_pods: "{{ smoketest_unhealthy_azure_logging_pods + [pod_name] }}"
       when: pod_phase != 'Running'
       # Make a subset of pods data for smaller log output
-      loop: |-
-        {% set comma = joiner(',') %}
-        [
-        {% for item in smoketest_azure_logging_pods.resources -%}
-          {{ comma() -}}
-          {
-            "metadata": { "name": "{{ item.metadata.name }}" },
-            "status": {
-              "phase": "{{ item.status.phase }}",
-              "containerStatuses": [{% for i in item.status.containerStatuses | d([]) -%}
-                {
-                    "name": "{{ i.name }}",
-                    "ready": "{{ i.ready }}",
-                    "restartCount": {{ i.restartCount }}
-                }{{ "," if not loop.last else "" }}
-              {% endfor -%}
-              ]
-            }
-          }{% endfor -%}
-        ]
+      loop: "{{ azure_logging_pods_json | from_json }}"
 
     - name: health_check | Assert all pods in openshift-azure-logging are healthy
       # Assert that no unhealthy pods exist in this namespace

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
@@ -139,14 +139,17 @@
       register: smoketest_firing_alerts_output
       delegate_to: "{{ delegation }}"
 
-    - name: health_check | Filter firing alerts based on severity
-      # Parse the output from amtool, removing any alerts matching ignored severity labels
+    - name: health_check | Filter firing alerts based on severity and expected alerts
+      # Parse the output from amtool, removing any alerts matching ignored severity
+      # labels, as well as any alerts explicitly expected for this cluster (e.g.
+      # clusters with deliberately broken DNS are expected to fire CoreDNSErrorsHigh).
       vars:
         all_alerts: "{{ smoketest_firing_alerts_output.stdout | from_json }}"
       ansible.builtin.set_fact:
         smoketest_filtered_alerts: >-
           {{ all_alerts
-             | rejectattr('labels.severity', 'in', smoketest_ignored_alert_severities)
+             | rejectattr('labels.severity', 'in', smoketest_ignored_alert_severities | d(['none', 'info']))
+             | rejectattr('labels.alertname', 'in', expected_alertmanager_alerts | d([]))
              | list }}
 
     - name: health_check | Print filtered alerts firing

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/health_check.yaml
@@ -66,10 +66,11 @@
         pod_phase: "{{ item.status.phase | d('Unknown') }}"
         container_restarts: "{{ item.status.containerStatuses | d([]) }}"
         restart_count_exceeded: "{{ container_restarts | selectattr('restartCount', '>', 1) | list | length > 0 }}"
-        # This template mixes literal "[" "]" text with control blocks, so Ansible
-        # renders it as a plain JSON string rather than a native list. Parse it with
-        # from_json below so `loop` gets an actual list.
-        azure_logging_pods_json: |-
+        # Depending on the Ansible/Jinja2 version, this bracket-templated text may already
+        # be auto-converted to a native list by literal_eval (since the loop body only ever
+        # emits valid Python/JSON literal syntax), or it may still come back as a plain
+        # string - so only parse with from_json when it's still a string.
+        azure_logging_pods_raw: |-
           {% set comma = joiner(',') %}
           [
           {% for item in smoketest_azure_logging_pods.resources -%}
@@ -89,11 +90,15 @@
               }
             }{% endfor -%}
           ]
+        azure_logging_pods_json: >-
+          {{ (azure_logging_pods_raw | from_json)
+             if (azure_logging_pods_raw is string)
+             else azure_logging_pods_raw }}
       ansible.builtin.set_fact:
         smoketest_unhealthy_azure_logging_pods: "{{ smoketest_unhealthy_azure_logging_pods + [pod_name] }}"
       when: pod_phase != 'Running'
       # Make a subset of pods data for smaller log output
-      loop: "{{ azure_logging_pods_json | from_json }}"
+      loop: "{{ azure_logging_pods_json }}"
 
     - name: health_check | Assert all pods in openshift-azure-logging are healthy
       # Assert that no unhealthy pods exist in this namespace

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/scale_nodes.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/roles/smoketest/tasks/scale_nodes.yaml
@@ -57,12 +57,18 @@
     namespace: openshift-machine-api
     kind: MachineSet
     name: "{{ smoketest_candidate_machineset.metadata.name }}"
-    resource_definition:
-      # Workaround to ensure the templated value is an integer not a string
-      spec: >-
-        {
-          "replicas": {{ smoketest_candidate_machineset.spec.replicas | d(1) - 1 }}
-        }
+    # Build the patch body as JSON text; depending on the Ansible/Jinja version,
+    # this may already be auto-converted to a native dict, or it may still be a
+    # plain string, so only run from_json when it's still a string. Either way
+    # this guarantees "replicas" ends up a native int, not a string (see
+    # node/cluster operator condition loops above for the same issue).
+    resource_definition: >-
+      {{ (scale_down_resource_definition_json | from_json)
+         if (scale_down_resource_definition_json is string)
+         else scale_down_resource_definition_json }}
+  vars:
+    scale_down_resource_definition_json: |
+      {"spec": {"replicas": {{ smoketest_candidate_machineset.spec.replicas | d(1) - 1 }}}}
   delegate_to: "{{ delegation }}"
 
 - name: scale_nodes | Wait for scale down
@@ -88,12 +94,13 @@
     namespace: openshift-machine-api
     kind: MachineSet
     name: "{{ smoketest_candidate_machineset.metadata.name }}"
-    resource_definition:
-      # Workaround to ensure the templated value is an integer not a string
-      spec: >-
-        {
-          "replicas": {{ smoketest_candidate_machineset.spec.replicas | d(1) }}
-        }
+    resource_definition: >-
+      {{ (scale_up_resource_definition_json | from_json)
+         if (scale_up_resource_definition_json is string)
+         else scale_up_resource_definition_json }}
+  vars:
+    scale_up_resource_definition_json: |
+      {"spec": {"replicas": {{ smoketest_candidate_machineset.spec.replicas | d(1) }}}}
   delegate_to: "{{ delegation }}"
 
 - name: scale_nodes | Wait for scale up

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -739,6 +739,59 @@
         var: update_ca_certificates.stdout_lines
         verbosity: 1
 
+- name: create_aro_cluster | Register oc_arch
+  ansible.builtin.set_fact:
+    oc_arch: >-
+      {{ oc_arch_map[localhost_facts.ansible_facts['ansible_architecture']] if delegation == "localhost"
+      else oc_arch_map[jumphost_facts.ansible_facts['ansible_architecture']] }}
+  vars:
+    oc_arch_map:
+      aarch64: arm64
+      x86_64: amd64
+
+- name: create_aro_cluster | Install `oc` binary from cluster
+  # Install oc as early as possible (right after kubeconfig/certs are ready), rather than
+  # after the cluster-health validation steps below, so it's available on the jumphost for
+  # manual troubleshooting even if this play later fails a health/progress check.
+  ansible.builtin.unarchive:
+    creates: "{{ oc_bin_file }}"
+    src: >
+      {{ aro_cluster_state.clusters.properties.consoleProfile.url
+         | replace('console-openshift-console', 'downloads-openshift-console')
+      }}{{ oc_arch }}/linux/oc.tar
+    remote_src: true
+    dest: "{{ oc_bin_file | dirname }}"
+    include: ["oc"]
+    mode: "0755"
+    validate_certs: "{% if rp_mode | d('production') == 'development' %}false{% else %}{{ omit }}{% endif %}"
+  become: "{{ delegation != 'localhost' }}"
+  delegate_to: "{{ delegation }}"
+- name: create_aro_cluster | Rename oc binary
+  ansible.builtin.file:
+    src: "{{ oc_bin_file | dirname }}/oc"
+    dest: "{{ oc_bin_file }}"
+    state: hard
+    mode: "0755"
+  become: "{{ delegation != 'localhost' }}"
+  delegate_to: "{{ delegation }}"
+- name: create_aro_cluster | Get oc version
+  ansible.builtin.command:
+    argv: "{{ argv | reject('equalto', omit) | list }}"
+  vars:
+    argv:
+      - "{{ oc_bin_file }}"
+      - version
+      - --kubeconfig={{ kubeconfig_file }}
+  delegate_to: "{{ delegation }}"
+  register: oc_version
+  changed_when: oc_version.rc == 0
+  retries: 3
+  delay: 60 # A few retries in case the certificate hasn't finished rolling out
+- name: create_aro_cluster | Show oc version
+  ansible.builtin.debug:
+    var: oc_version.stdout_lines
+    verbosity: 1
+
 - name: create_aro_cluster | Install current version release-image signature to make CVO happy
   when: outbound_type | d("LoadBalancer") == "UserDefinedRouting"
   block:
@@ -977,56 +1030,6 @@
     (item.condition.type == "Degraded" and item.condition.status != "False")
   ansible.builtin.fail:
     msg: "Cluster operator {{ item.name }} {{ item.condition.type }} is {{ item.condition.status }}."
-
-- name: create_aro_cluster | Register oc_arch
-  ansible.builtin.set_fact:
-    oc_arch: >-
-      {{ oc_arch_map[localhost_facts.ansible_facts['ansible_architecture']] if delegation == "localhost"
-      else oc_arch_map[jumphost_facts.ansible_facts['ansible_architecture']] }}
-  vars:
-    oc_arch_map:
-      aarch64: arm64
-      x86_64: amd64
-
-- name: create_aro_cluster | Install `oc` binary from cluster
-  ansible.builtin.unarchive:
-    creates: "{{ oc_bin_file }}"
-    src: >
-      {{ aro_cluster_state.clusters.properties.consoleProfile.url
-         | replace('console-openshift-console', 'downloads-openshift-console')
-      }}{{ oc_arch }}/linux/oc.tar
-    remote_src: true
-    dest: "{{ oc_bin_file | dirname }}"
-    include: ["oc"]
-    mode: "0755"
-    validate_certs: "{% if rp_mode | d('production') == 'development' %}false{% else %}{{ omit }}{% endif %}"
-  become: "{{ delegation != 'localhost' }}"
-  delegate_to: "{{ delegation }}"
-- name: create_aro_cluster | Rename oc binary
-  ansible.builtin.file:
-    src: "{{ oc_bin_file | dirname }}/oc"
-    dest: "{{ oc_bin_file }}"
-    state: hard
-    mode: "0755"
-  become: "{{ delegation != 'localhost' }}"
-  delegate_to: "{{ delegation }}"
-- name: create_aro_cluster | Get oc version
-  ansible.builtin.command:
-    argv: "{{ argv | reject('equalto', omit) | list }}"
-  vars:
-    argv:
-      - "{{ oc_bin_file }}"
-      - version
-      - --kubeconfig={{ kubeconfig_file }}
-  delegate_to: "{{ delegation }}"
-  register: oc_version
-  changed_when: oc_version.rc == 0
-  retries: 3
-  delay: 60 # A few retries in case the certificate hasn't finished rolling out
-- name: create_aro_cluster | Show oc version
-  ansible.builtin.debug:
-    var: oc_version.stdout_lines
-    verbosity: 1
 
 - name: create_aro_cluster | Enable cluster wide proxy
   when: cluster_wide_proxy | d(false)

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -594,8 +594,6 @@
     src: "{{ kubeconfig_file }}"
     dest: "{{ kubeconfig_file }}"
     mode: "0644"
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_gid }}"
   delegate_to: "{{ delegation }}"
 
 - name: create_aro_cluster | Cluster api certificate
@@ -696,8 +694,6 @@
       live ingress certificate (possibly interim self-signed):
       {% for item in ingress_certificate.verified_chain %}{{ item }}{% endfor %}
     mode: "0600"
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_gid }}"
   delegate_to: "{{ delegation }}"
 
 - name: create_aro_cluster | Debug cluster_ca_certificate

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -1008,6 +1008,7 @@
     dest: "{{ oc_bin_file }}"
     state: hard
     mode: "0755"
+  become: "{{ delegation != 'localhost' }}"
   delegate_to: "{{ delegation }}"
 - name: create_aro_cluster | Get oc version
   ansible.builtin.command:

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -964,10 +964,12 @@
 
 - name: create_aro_cluster | Validate node conditions
   vars:
-    # This template mixes literal "[" "]" text with control blocks, so Ansible
-    # renders the result as a plain JSON string rather than a native list.
-    # Parse it with from_json so `loop` gets an actual list.
-    node_conditions_json: |-
+    # Depending on the Ansible/Jinja2 version, this bracket-templated text may already be
+    # auto-converted to a native list by literal_eval (since the loop body only ever emits
+    # valid Python/JSON literal syntax), or it may still come back as a plain string - so
+    # only parse with from_json when it's still a string (same pattern used for the
+    # MachineSet scale patch in the smoketest role and clusteroperator_progressing above).
+    node_conditions_raw: |-
       {% set comma = joiner(",") -%}
       [{%- for node in oc_get_nodes.resources -%}
         {%- for c in node.status.conditions -%}
@@ -978,7 +980,11 @@
           }{%- endfor -%}
       {%- endfor -%}
       ]
-  loop: "{{ node_conditions_json | from_json }}"
+    node_conditions_json: >-
+      {{ (node_conditions_raw | from_json)
+         if (node_conditions_raw is string)
+         else node_conditions_raw }}
+  loop: "{{ node_conditions_json }}"
   when: (item.condition.type == "Ready" and item.condition.status != "True") or
     (item.condition.type != "Ready" and item.condition.status != "False")
   ansible.builtin.fail:
@@ -986,9 +992,10 @@
 
 - name: create_aro_cluster | Validate cluster operator conditions
   vars:
-    # Same string-vs-list issue as above; also switched `{{ c }}` (Python repr,
-    # single-quoted, invalid JSON) to `{{ c | to_json }}` so from_json can parse it.
-    co_conditions_json: |-
+    # Same string-vs-list ambiguity as above; also switched `{{ c }}` (Python repr,
+    # single-quoted, invalid JSON) to `{{ c | to_json }}` so from_json can parse it
+    # when the raw text does come back as a string.
+    co_conditions_raw: |-
       {% set comma = joiner(",") %}
       [{%- for co in oc_get_co.resources -%}
         {%- for c in co.status.conditions -%}
@@ -1000,7 +1007,11 @@
           }{%- endif %}{% endfor -%}
       {%- endfor -%}
       ]
-  loop: "{{ co_conditions_json | from_json }}"
+    co_conditions_json: >-
+      {{ (co_conditions_raw | from_json)
+         if (co_conditions_raw is string)
+         else co_conditions_raw }}
+  loop: "{{ co_conditions_json }}"
   when:
     (item.condition.type == "Available" and item.condition.status != "True") or
     (item.condition.type == "Degraded" and item.condition.status != "False")
@@ -1017,9 +1028,10 @@
   register: oc_get_co
 - name: create_aro_cluster | Validate cluster operator conditions
   vars:
-    # Same string-vs-list issue as above; also switched `{{ c }}` (Python repr,
-    # single-quoted, invalid JSON) to `{{ c | to_json }}` so from_json can parse it.
-    co_conditions_json: |-
+    # Same string-vs-list ambiguity as above; also switched `{{ c }}` (Python repr,
+    # single-quoted, invalid JSON) to `{{ c | to_json }}` so from_json can parse it
+    # when the raw text does come back as a string.
+    co_conditions_raw: |-
       {% set comma = joiner(",") %}
       [{%- for co in oc_get_co.resources -%}
         {%- for c in co.status.conditions -%}
@@ -1031,7 +1043,11 @@
           }{%- endif %}{% endfor -%}
       {%- endfor -%}
       ]
-  loop: "{{ co_conditions_json | from_json }}"
+    co_conditions_json: >-
+      {{ (co_conditions_raw | from_json)
+         if (co_conditions_raw is string)
+         else co_conditions_raw }}
+  loop: "{{ co_conditions_json }}"
   when:
     (item.condition.type == "Available" and item.condition.status != "True") or
     (item.condition.type == "Degraded" and item.condition.status != "False")

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -903,35 +903,44 @@
   delay: 60 # A few retries in case the certificate hasn't finished rolling out
 
 - name: create_aro_cluster | Validate node conditions
-  loop: |
-    {% set comma = joiner(",") -%}
-    [{%- for node in oc_get_nodes.resources -%}
-      {%- for c in node.status.conditions -%}
-        {{ comma() }}
-        {
-          "name": "{{ node.metadata.name }}",
-          "condition": {{ c | to_json }}
-        }{%- endfor -%}
-    {%- endfor -%}
-    ]
+  vars:
+    # This template mixes literal "[" "]" text with control blocks, so Ansible
+    # renders the result as a plain JSON string rather than a native list.
+    # Parse it with from_json so `loop` gets an actual list.
+    node_conditions_json: |-
+      {% set comma = joiner(",") -%}
+      [{%- for node in oc_get_nodes.resources -%}
+        {%- for c in node.status.conditions -%}
+          {{ comma() }}
+          {
+            "name": "{{ node.metadata.name }}",
+            "condition": {{ c | to_json }}
+          }{%- endfor -%}
+      {%- endfor -%}
+      ]
+  loop: "{{ node_conditions_json | from_json }}"
   when: (item.condition.type == "Ready" and item.condition.status != "True") or
     (item.condition.type != "Ready" and item.condition.status != "False")
   ansible.builtin.fail:
     msg: "Condition {{ item.condition.type }} is not acceptible on node {{ item.name }}"
 
 - name: create_aro_cluster | Validate cluster operator conditions
-  loop: |
-    {% set comma = joiner(",") %}
-    [{%- for co in oc_get_co.resources -%}
-      {%- for c in co.status.conditions -%}
-        {%- if c.type == "Available" or c.type == "Degraded" -%}
-        {{ comma() }}
-        {
-          "name": "{{ co.metadata.name }}",
-          "condition": {{ c }}
-        }{%- endif %}{% endfor -%}
-    {%- endfor -%}
-    ]
+  vars:
+    # Same string-vs-list issue as above; also switched `{{ c }}` (Python repr,
+    # single-quoted, invalid JSON) to `{{ c | to_json }}` so from_json can parse it.
+    co_conditions_json: |-
+      {% set comma = joiner(",") %}
+      [{%- for co in oc_get_co.resources -%}
+        {%- for c in co.status.conditions -%}
+          {%- if c.type == "Available" or c.type == "Degraded" -%}
+          {{ comma() }}
+          {
+            "name": "{{ co.metadata.name }}",
+            "condition": {{ c | to_json }}
+          }{%- endif %}{% endfor -%}
+      {%- endfor -%}
+      ]
+  loop: "{{ co_conditions_json | from_json }}"
   when:
     (item.condition.type == "Available" and item.condition.status != "True") or
     (item.condition.type == "Degraded" and item.condition.status != "False")
@@ -947,18 +956,22 @@
   delegate_to: "{{ delegation }}"
   register: oc_get_co
 - name: create_aro_cluster | Validate cluster operator conditions
-  loop: |
-    {% set comma = joiner(",") %}
-    [{%- for co in oc_get_co.resources -%}
-      {%- for c in co.status.conditions -%}
-        {%- if c.type == "Available" or c.type == "Degraded" -%}
-        {{ comma() }}
-        {
-          "name": "{{ co.metadata.name }}",
-          "condition": {{ c }}
-        }{%- endif %}{% endfor -%}
-    {%- endfor -%}
-    ]
+  vars:
+    # Same string-vs-list issue as above; also switched `{{ c }}` (Python repr,
+    # single-quoted, invalid JSON) to `{{ c | to_json }}` so from_json can parse it.
+    co_conditions_json: |-
+      {% set comma = joiner(",") %}
+      [{%- for co in oc_get_co.resources -%}
+        {%- for c in co.status.conditions -%}
+          {%- if c.type == "Available" or c.type == "Degraded" -%}
+          {{ comma() }}
+          {
+            "name": "{{ co.metadata.name }}",
+            "condition": {{ c | to_json }}
+          }{%- endif %}{% endfor -%}
+      {%- endfor -%}
+      ]
+  loop: "{{ co_conditions_json | from_json }}"
   when:
     (item.condition.type == "Available" and item.condition.status != "True") or
     (item.condition.type == "Degraded" and item.condition.status != "False")

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -853,9 +853,11 @@
       delegate_to: "{{ delegation }}"
       register: oc_get_co
       vars:
-        # Changing this to a simple string, because trying to return an array
-        # was resulting in clusteroperator_progressing | length == 2, as though
-        # the empty array was the string "[]"
+        # This template mixes literal "[" "]" text with control blocks, so Ansible
+        # renders clusteroperator_progressing as a plain string rather than a native
+        # list. That means the empty case renders as the literal string "[]" (length 2),
+        # so `| length > 0` is always true regardless of actual operator state.
+        # Compare against the literal empty-array string instead.
         clusteroperator_progressing: |-
           {% set comma = joiner(",") %}
           [{%- for co in oc_get_co.resources -%}
@@ -865,7 +867,7 @@
           {%- endif %}{% endfor -%}
           {%- endfor -%}
           ]
-      failed_when: clusteroperator_progressing | length > 0
+      failed_when: clusteroperator_progressing != "[]"
       retries: 60
       delay: 60
   rescue:

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -582,8 +582,8 @@
     content: "{{ new_kubeconfig_content }}"
     dest: "{{ kubeconfig_file }}"
     mode: "0600"
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_gid }}"
+    owner: "{{ ansible_facts['user_id'] }}"
+    group: "{{ ansible_facts['user_gid'] }}"
   when: kubeconfig_changed
   delegate_to: localhost
   changed_when: true

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/create_aro_cluster.yaml
@@ -906,12 +906,15 @@
       delegate_to: "{{ delegation }}"
       register: oc_get_co
       vars:
-        # This template mixes literal "[" "]" text with control blocks, so Ansible
-        # renders clusteroperator_progressing as a plain string rather than a native
-        # list. That means the empty case renders as the literal string "[]" (length 2),
-        # so `| length > 0` is always true regardless of actual operator state.
-        # Compare against the literal empty-array string instead.
-        clusteroperator_progressing: |-
+        # Since the loop body only ever emits quoted operator names, the rendered text is
+        # always valid Python/JSON list syntax ("[]" or ["opA","opB"]). Ansible's Jinja2
+        # native-types renderer runs literal_eval() on that text, so this *always* comes
+        # back as a native list already (in every Ansible version/host we've observed) -
+        # never the literal string "[]", even in the empty case. But to stay robust in case
+        # some other Ansible/Jinja version ever renders it as a plain string instead, only
+        # parse with from_json when it's still a string (same pattern used for the
+        # MachineSet scale patch in the smoketest role), then just check its length.
+        clusteroperator_progressing_raw: |-
           {% set comma = joiner(",") %}
           [{%- for co in oc_get_co.resources -%}
             {%- for c in co.status.conditions -%}
@@ -920,7 +923,11 @@
           {%- endif %}{% endfor -%}
           {%- endfor -%}
           ]
-      failed_when: clusteroperator_progressing != "[]"
+        clusteroperator_progressing: >-
+          {{ (clusteroperator_progressing_raw | from_json)
+             if (clusteroperator_progressing_raw is string)
+             else clusteroperator_progressing_raw }}
+      failed_when: clusteroperator_progressing | length > 0
       retries: 60
       delay: 60
   rescue:

--- a/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
+++ b/ansible/collections/ansible_collections/azureredhatopenshift/cluster/tasks/upgrade_cluster.yaml
@@ -219,7 +219,7 @@
         resource_definition:
           spec:
             desiredUpdate:
-              architecture": ""
+              architecture: ""
               force: "{{ upgrade_item.force | d(False) | bool }}"
               image: "{{ ocp_explicit_image | d(upgrade_item.image) | d('') }}"
               version: "{{ upgrade_item.version | d('') }}"
@@ -258,9 +258,20 @@
         conditions: |-
           {{ oc_get_clusterversion.resources[0].status.conditions
           | items2dict(key_name="type", value_name="status") }}
+      # Checking only "not currently Progressing" is a false-positive trap: if the
+      # desiredUpdate patch above never actually gets picked up by the CVO (e.g. it's
+      # rejected, or otherwise a no-op), Progressing stays "False" from the very first
+      # poll and this task reports success immediately, without the cluster ever having
+      # moved off its starting version. Also require that status.desired.version has
+      # actually changed from the pre-upgrade version and that its history entry shows
+      # "Completed", so a stalled/rejected/no-op update is correctly treated as a failure
+      # that keeps retrying (and eventually times out with a clear error) instead of
+      # silently "succeeding".
       failed_when: |-
         conditions.get("Progressing", "True") == "True"
         or conditions.get("ReleaseAccepted", "True") == "False"
+        or desired_version == gate_desired_version
+        or version_history.get(desired_version, "Unknown") != "Completed"
       retries: 120
       delay: 60
     - name: upgrade_cluster | Show clusterversion conditions

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -165,6 +165,34 @@ udr_clusters:
       nsgs:
         - name: custom_nsg
           rules: []
+    udr420:
+      cluster_name: aro
+      version: 4.20.15
+      HAS_INTERNET: false
+      enable_preconfigured_nsg: true
+      worker_nsg: custom_nsg
+      master_nsg: custom_nsg
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+      nsgs:
+        - name: custom_nsg
+          rules: []
+    udr421:
+      cluster_name: aro
+      version: 4.21.22
+      HAS_INTERNET: false
+      enable_preconfigured_nsg: true
+      worker_nsg: custom_nsg
+      master_nsg: custom_nsg
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+      nsgs:
+        - name: custom_nsg
+          rules: []
 
   vars:
     resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"

--- a/ansible/hosts.yaml
+++ b/ansible/hosts.yaml
@@ -62,6 +62,9 @@ baddns_clusters:
     resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
     dns_servers:
       - 172.16.0.0
+    # Broken DNS above is expected to make CoreDNS log lookup failures.
+    expected_alertmanager_alerts:
+      - CoreDNSErrorsHigh
     network_prefix_cidr: 10.0.0.0/22
     master_cidr: 10.0.0.0/23
     master_vm_size: Standard_D8s_v3

--- a/ansible/inventory/smoketest-4.15.35.yaml
+++ b/ansible/inventory/smoketest-4.15.35.yaml
@@ -81,3 +81,6 @@ udr_clusters:
     # Need to break DNS, because Azure DNS is reachable even with a blackhole default route
     dns_servers:
       - 172.16.0.0
+    # Broken DNS above is expected to make CoreDNS log lookup failures.
+    expected_alertmanager_alerts:
+      - CoreDNSErrorsHigh

--- a/ansible/inventory/smoketest-4.16.30.yaml
+++ b/ansible/inventory/smoketest-4.16.30.yaml
@@ -81,3 +81,6 @@ udr_clusters:
     # Need to break DNS, because Azure DNS is reachable even with a blackhole default route
     dns_servers:
       - 172.16.0.0
+    # Broken DNS above is expected to make CoreDNS log lookup failures.
+    expected_alertmanager_alerts:
+      - CoreDNSErrorsHigh

--- a/ansible/inventory/smoketest-4.21.22.yaml
+++ b/ansible/inventory/smoketest-4.21.22.yaml
@@ -1,0 +1,83 @@
+---
+standard_clusters:
+  # "standard" in the sense that the unspecialized standard_cluster role will work
+  # See byok_cluster for an example that is not "standard"
+  hosts:
+    basic:
+      # The simplest possible cluster
+      cluster_name: aro
+      version: 4.21.22
+    enc:
+      # Basic cluster with encryption-at-host enabled
+      cluster_name: aro-421
+      version: 4.21.22
+      master_vm_size: Standard_E8s_v5
+      master_encryption_at_host: true
+      worker_vm_size: Standard_D4s_v5
+      worker_encryption_at_host: true
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_vm_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_vm_size: Standard_D4s_v3
+  children:
+    encrypted_clusters:
+    private_clusters:
+    udr_clusters:
+
+byok_clusters:
+  # Cluster with customer-managed disk encryption key
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-byok
+  hosts:
+    byok:
+      cluster_name: aro
+      version: 4.21.22
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_vm_size: Standard_E8s_v5
+    worker_cidr: 10.0.2.0/23
+    worker_vm_size: Standard_D4s_v5
+
+private_clusters:
+  hosts:
+    private:
+      # Simple private cluster, no UDR
+      cluster_name: aro
+      version: 4.21.22
+  vars:
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    master_vm_size: Standard_D8s_v3
+    worker_cidr: 10.0.2.0/23
+    worker_vm_size: Standard_D4s_v3
+
+
+udr_clusters:
+  # https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x
+  hosts:
+    udr:
+      cluster_name: aro
+      version: 4.21.22
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
+  vars:
+    HAS_INTERNET: false
+    resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"
+    network_prefix_cidr: 10.0.0.0/22
+    master_cidr: 10.0.0.0/23
+    worker_cidr: 10.0.2.0/23
+    apiserver_visibility: Private
+    ingress_visibility: Private
+    outbound_type: UserDefinedRouting
+    # Need to break DNS, because Azure DNS is reachable even with a blackhole default route
+    dns_servers:
+      - 172.16.0.0

--- a/ansible/inventory/smoketest-4.21.22.yaml
+++ b/ansible/inventory/smoketest-4.21.22.yaml
@@ -81,3 +81,6 @@ udr_clusters:
     # Need to break DNS, because Azure DNS is reachable even with a blackhole default route
     dns_servers:
       - 172.16.0.0
+    # Broken DNS above is expected to make CoreDNS log lookup failures.
+    expected_alertmanager_alerts:
+      - CoreDNSErrorsHigh

--- a/ansible/inventory/smoketest-udr.yaml
+++ b/ansible/inventory/smoketest-udr.yaml
@@ -19,6 +19,12 @@ udr_clusters:
     udr416:
       version: 4.16.30
       create_csp: true
+    udr420:
+      version: 4.20.15
+      create_csp: true
+    udr421:
+      version: 4.21.22
+      create_csp: true
   vars:
     cluster_name: aro
     resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"

--- a/ansible/inventory/smoketest-udr.yaml
+++ b/ansible/inventory/smoketest-udr.yaml
@@ -41,6 +41,9 @@ udr_clusters:
       # Break DNS with an impossible address, because the default 168.63.129.16 is always reachable
       # https://learn.microsoft.com/en-us/azure/openshift/howto-custom-dns
       - 172.16.0.0
+    # Broken DNS above is expected to make CoreDNS log lookup failures.
+    expected_alertmanager_alerts:
+      - CoreDNSErrorsHigh
     domain: "{{ inventory_hostname }}.{{ location }}.private"
     routes:
       - name: Blackhole

--- a/ansible/inventory/smoketest-udr.yaml
+++ b/ansible/inventory/smoketest-udr.yaml
@@ -25,7 +25,9 @@ udr_clusters:
     HAS_INTERNET: false
     network_prefix_cidr: 10.0.0.0/22
     master_cidr: 10.0.0.0/23
+    master_vm_size: Standard_D8s_v3
     worker_cidr: 10.0.2.0/23
+    worker_vm_size: Standard_D4s_v3
     apiserver_visibility: Private
     ingress_visibility: Private
     outbound_type: UserDefinedRouting

--- a/ansible/inventory/upgrades-candidate.yaml
+++ b/ansible/inventory/upgrades-candidate.yaml
@@ -110,12 +110,18 @@ all:
           admin_acks:
             - {"data":{"ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20":"true"}}
       candidate_421: &upgrade_candidate_421
-        # TODO: confirm whether any admin_acks are required for the 4.20 -> 4.21 transition; see
-        # https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/updating_clusters/
-        #   preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
+        # 4.21 requires Sigstore signatures for quay.io/openshift-release-dev/ocp-release
+        # release verification; clusters with mirrors configured (ImageContentSourcePolicy/
+        # ImageDigestMirrorSet) are blocked from updating to 4.21 until this is acknowledged.
+        # ARO clusters already have the required Sigstore signature images provided by the
+        # service, so no further action beyond the ack is necessary. See
+        # https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/nodes-sigstore-using
+        #   and https://learn.microsoft.com/en-us/azure/openshift/howto-upgrade#updating-from-420-to-421
         - from: "4.20"
           channel: stable-4.21
           version: 4.21.22
+          admin_acks:
+            - { "data": { "ack-4.20-sigstore-in-4.21": "true" } }
 
 standard_clusters:
   # "standard" in the sense that the unspecialized standard_cluster role will work

--- a/ansible/inventory/upgrades-candidate.yaml
+++ b/ansible/inventory/upgrades-candidate.yaml
@@ -158,6 +158,9 @@ baddns_clusters:
     HAS_INTERNET: false
     dns_servers:
       - 172.16.0.0
+    # Broken DNS above is expected to make CoreDNS log lookup failures.
+    expected_alertmanager_alerts:
+      - CoreDNSErrorsHigh
     network_prefix_cidr: 10.0.0.0/22
     master_cidr: 10.0.0.0/23
     master_vm_size: Standard_D8s_v3

--- a/ansible/inventory/upgrades-candidate.yaml
+++ b/ansible/inventory/upgrades-candidate.yaml
@@ -109,6 +109,13 @@ all:
           allow-not-recommended: true
           admin_acks:
             - {"data":{"ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20":"true"}}
+      candidate_421: &upgrade_candidate_421
+        # TODO: confirm whether any admin_acks are required for the 4.20 -> 4.21 transition; see
+        # https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/updating_clusters/
+        #   preparing-to-update-a-cluster#kube-api-removals_updating-cluster-prepare
+        - from: "4.20"
+          channel: stable-4.21
+          version: 4.21.22
 
 standard_clusters:
   # "standard" in the sense that the unspecialized standard_cluster role will work
@@ -220,6 +227,9 @@ udr_clusters:
     udr-420:
       version: 4.18.26
       upgrade: *upgrade_candidate_420
+    udr-421:
+      version: 4.20.15
+      upgrade: *upgrade_candidate_421
   vars:
     cluster_name: aro
     resource_group: "{{ CLUSTERPREFIX }}-{{ inventory_hostname }}-{{ location }}"

--- a/ansible/inventory/upgrades.yaml
+++ b/ansible/inventory/upgrades.yaml
@@ -331,6 +331,9 @@ baddns_clusters:
     HAS_INTERNET: false
     dns_servers:
       - 172.16.0.0
+    # Broken DNS above is expected to make CoreDNS log lookup failures.
+    expected_alertmanager_alerts:
+      - CoreDNSErrorsHigh
     network_prefix_cidr: 10.0.0.0/22
     master_cidr: 10.0.0.0/23
     master_vm_size: Standard_D8s_v3

--- a/ansible/inventory/upgrades.yaml
+++ b/ansible/inventory/upgrades.yaml
@@ -409,6 +409,14 @@ private_clusters:
 udr_clusters:
   # https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x
   hosts:
+    udr421:
+      cluster_name: aro
+      version: 4.21.22
+      HAS_INTERNET: false
+      routes:
+        - name: Blackhole
+          address_prefix: 0.0.0.0/0
+          next_hop_type: none
     udr416:
       cluster_name: aro
       version: 4.16.30

--- a/utils/build-ansible-image.py
+++ b/utils/build-ansible-image.py
@@ -2,6 +2,7 @@
 
 import requests
 import json
+import shlex
 from urllib.parse import urljoin
 from pprint import pprint
 from sys import argv, stdout, stderr
@@ -12,7 +13,12 @@ from time import strptime
 from datetime import datetime, UTC
 
 galaxyBaseUrl="https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/"
-buildArgv=["buildah", "build",
+# Use `podman build` rather than invoking `buildah` directly: buildah isn't
+# available as a standalone binary in every environment that has podman (e.g.
+# macOS with Podman Desktop/machine only exposes the `podman` CLI on the host),
+# whereas `podman build` is available everywhere podman itself is used
+# elsewhere in this repo's Makefile.
+buildArgv=["podman", "build",
         '--format', 'docker',
 		"--tag", "aro-ansible:latest"
     ]
@@ -93,11 +99,14 @@ if __name__ == "__main__":
     )
     parser.add_argument("dockerfile", help="Path to the Dockerfile")
     parser.add_argument('--latest', action='store_true', help='Use "latest" to build with latest versions of everything')
-    parser.add_argument('--build-arg', action='append', default=list(), help='Additional build arguments to pass to buildah')
+    parser.add_argument('--build-arg', action='append', default=list(), help='Additional build arguments to pass to podman build')
     parser.add_argument('--tag', action='append', default=list(), help='Additional tags for the built image')
+    parser.add_argument('--podman-remote-args', default='', help='Extra args inserted between "podman" and "build" (e.g. for a remote connection); same as PODMAN_REMOTE_ARGS elsewhere in the Makefile')
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output')
-    parser.add_argument('--dry-run', action='store_true', help='Do not actually run buildah, just print the command line')
+    parser.add_argument('--dry-run', action='store_true', help='Do not actually run podman, just print the command line')
     args = parser.parse_args()
+    if args.podman_remote_args.strip():
+        buildArgv[1:1] = shlex.split(args.podman_remote_args)
     buildArgv.append("--file")
     buildArgv.append(args.dockerfile)
     for t in args.tag:


### PR DESCRIPTION
Adds udr420/udr421 UDR cluster pattern support along with a udr420 → udr421 in-place upgrade path, and fixes a series of bugs surfaced while running cluster creation, smoketests, and upgrades end-to-end against them.

New cluster pattern & upgrade path

- Add udr420/udr421 UDR host entries (hosts.yaml, smoketest-udr.yaml, upgrades.yaml) and a smoketest-4.21.22.yaml inventory mirroring the existing 4.15/4.16 smoketest pattern.
- Add a candidate_421 upgrade path (4.20 → stable-4.21 → 4.21.22) and a udr-421 host starting at 4.20.15, so the udr candidate suite can exercise an in-place 4.20 → 4.21 upgrade rather than only fresh-creating clusters per version.
- Add the required ack-4.20-sigstore-in-4.21 admin-ack, since 4.21 requires Sigstore signature verification for mirrored clusters and ARO clusters get blocked on Upgradeable: False (AdminAckRequired) without it.

Cluster creation fixes

- Fix az aro create failing with InvalidParameter for worker VM size by setting master_vm_size/worker_vm_size for UDR clusters.
- Fix chown: Operation not permitted copying the kubeconfig/serving cert to the jumphost by dropping the explicit owner/group (files should just land owned by the connecting jumphost user).
- Fix oc binary rename Operation not permitted on the jumphost (hard-linking a root-owned binary needs become due to protected_hardlinks).
- Move oc installation earlier in the playbook (right after kubeconfig/certs are ready), so the jumphost still has a usable oc binary even when a cluster fails health validation and needs manual troubleshooting.
- Replace deprecated ansible_user_id/ansible_user_gid with ansible_facts['user_id']/ansible_facts['user_gid'].
- Pin cryptography to a known-good version to avoid a SIGILL crash in ansible-galaxy on ARM64 Podman (Apple Silicon).

Templating/native-list correctness (the trickiest bug class in this PR)

- Several Jinja2 templates built JSON-like text ("[" ... "]") for use in loop:/failed_when:. Depending on the Ansible/Jinja version, that text can render as either a plain string or get auto-coerced into a native Python list/dict via literal_eval. Code that assumed only one of those two behaviors caused two real, reproducible bugs:

-   - create_aro_cluster | Wait for cluster operators to stop progressing retried all 60 attempts and failed even when oc get co showed every operator healthy, because failed_when string-compared a value that was actually already a native empty list.
-   - MachineSet scale-up/down patches were rejected by the Kubernetes API (spec in body must be of type object: string) because replicas was sent as a string instead of a native int.
-   - Node/cluster-operator condition validation and the unhealthy-pod check hit The loop value must resolve to a list, not str.

- Fixed by normalizing each value with a "parse with from_json only if it's still a string, otherwise use as-is" pattern, applied consistently everywhere this templating idiom is used (cluster operator progressing check, node conditions, cluster operator conditions ×2, azure-logging pod health check, MachineSet scale patches).

Smoketest health checks

- Allow expected/known alerts (e.g. CoreDNSErrorsHigh) on clusters that deliberately break DNS (UDR/baddns), via a new expected_alertmanager_alerts allowlist filtered by alert name, defaulting to [] and set to [CoreDNSErrorsHigh] on the relevant inventories.
Upgrade correctness

- Fix a typo'd architecture" key in the desiredUpdate patch that silently sent a malformed field instead of the intended one.
- Fix Wait for upgrade to complete reporting success on a no-op upgrade: it only checked Progressing == "True", so a patch that never got picked up by the CVO (rejected/ignored) reported success immediately without the cluster ever changing version. Now also requires status.desired.version to have actually changed and its history entry to show "Completed".
Build tooling

- Switch build-ansible-image.py from buildah build to podman build (threading through PODMAN_REMOTE_ARGS), since buildah isn't available as a standalone binary on macOS Podman Desktop/machine setups.

Test plan

-  make cluster LOCATION=westus2 INVENTORY=inventory/smoketest-udr.yaml CLUSTERPATTERN=udr421 CLUSTERPREFIX=<prefix> — fresh cluster create + smoketest completes successfully.

-  make cluster LOCATION=westus2 INVENTORY=inventory/upgrades-candidate.yaml CLUSTERPATTERN=candidate_421 CLUSTERPREFIX=<prefix>  — udr420 → udr421 in-place upgrade completes and oc get clusterversion shows the version actually advanced to 4.21.22 with Completed history.

-  Confirm no firing-alerts failures on UDR/baddns clusters other than the expected CoreDNSErrorsHigh.

-  make ansible-image builds successfully on macOS Podman.